### PR TITLE
Minor contracts fixes

### DIFF
--- a/contracts/contracts/Franklin.sol
+++ b/contracts/contracts/Franklin.sol
@@ -479,10 +479,7 @@ contract Franklin {
             _blockNumber == totalBlocksCommitted + 1,
             "fck11"
         ); // fck11 - only commit next block
-        require(
-            governance.isValidator(msg.sender),
-            "fck12"
-        ); // fck12 - not a validator in commit
+        governance.requireActiveValidator(msg.sender);
         if(!triggerRevertIfBlockCommitmentExpired() && !triggerExodusIfNeeded()) {
             require(
                 totalBlocksCommitted - totalBlocksVerified < MAX_UNVERIFIED_BLOCKS,
@@ -701,10 +698,7 @@ contract Franklin {
             _blockNumber == totalBlocksVerified + 1,
             "fvk11"
         ); // fvk11 - only verify next block
-        require(
-            governance.isValidator(msg.sender),
-            "fvk12"
-        ); // fvk12 - not a validator in verify
+        governance.requireActiveValidator(msg.sender);
 
         require(
             verifier.verifyBlockProof(_proof, blocks[_blockNumber].commitment),

--- a/contracts/contracts/Governance.sol
+++ b/contracts/contracts/Governance.sol
@@ -4,7 +4,7 @@ pragma solidity 0.5.10;
 /// @author Matter Labs
 contract Governance {
 
-    /// @notice Token added to Rollup net
+    /// @notice Token added to Franklin net
     event TokenAdded(
         address token,
         uint16 tokenId

--- a/contracts/contracts/Governance.sol
+++ b/contracts/contracts/Governance.sol
@@ -72,7 +72,7 @@ contract Governance {
 
     /// @notice Checks if validator is active
     /// @param _address Validator address
-    function requireActiveValidator(address _address) public view {
+    function requireActiveValidator(address _address) external view {
         require(
             validators[_address],
             "grr21"
@@ -82,7 +82,7 @@ contract Governance {
     /// @notice Validate token id (must be less than total tokens amount)
     /// @param _tokenId Token id
     /// @return bool flag that indicates if token id is less than total tokens amount
-    function isValidTokenId(uint16 _tokenId) public view returns (bool) {
+    function isValidTokenId(uint16 _tokenId) external view returns (bool) {
         return _tokenId < totalTokens + 1;
     }
 

--- a/contracts/contracts/Governance.sol
+++ b/contracts/contracts/Governance.sol
@@ -4,7 +4,7 @@ pragma solidity 0.5.10;
 /// @author Matter Labs
 contract Governance {
 
-    /// @notice Token added to Franklin net
+    /// @notice Token added to Rollup net
     event TokenAdded(
         address token,
         uint16 tokenId
@@ -35,14 +35,14 @@ contract Governance {
     /// @notice Change current governor
     /// @param _newGovernor Address of the new governor
     function changeGovernor(address _newGovernor) external {
-        requireGovernor();
+        requireGovernor(msg.sender);
         networkGovernor = _newGovernor;
     }
 
     /// @notice Add token to the list of networks tokens
     /// @param _token Token address
     function addToken(address _token) external {
-        requireGovernor();
+        requireGovernor(msg.sender);
         require(
             tokenIds[_token] == 0,
             "gan11"
@@ -57,32 +57,26 @@ contract Governance {
     /// @param _validator Validator address
     /// @param _active Active flag
     function setValidator(address _validator, bool _active) external {
-        requireGovernor();
+        requireGovernor(msg.sender);
         validators[_validator] = _active;
     }
 
-    /// @notice Check if the sender is governor
-    function requireGovernor() internal view {
+    /// @notice Check if specified address is is governor
+    /// @param _address Address to check
+    function requireGovernor(address _address) public view {
         require(
-            msg.sender == networkGovernor,
+            _address == networkGovernor,
             "grr11"
         ); // grr11 - only by governor
     }
 
-    /// @notice Return validator status (active or not)
-    /// @param _sender Validator address
-    /// @return bool flag that indicates validator status
-    function isValidator(address _sender) external view returns (bool) {
-        return validators[_sender];
-    }
-
-    /// @notice Validate token id (must be less than total tokens amount)
-    /// @param _tokenId Token id
-    function requireValidTokenId(uint16 _tokenId) external view {
+    /// @notice Checks if validator is active
+    /// @param _address Validator address
+    function requireActiveValidator(address _address) public view {
         require(
-            _tokenId < totalTokens + 1,
-            "grd11"
-        ); // grd11 - unknown token id
+            validators[_address],
+            "grr21"
+        ); // grr21 - validator is not active
     }
 
     /// @notice Validate token id (must be less than total tokens amount)

--- a/contracts/contracts/PriorityQueue.sol
+++ b/contracts/contracts/PriorityQueue.sol
@@ -7,7 +7,7 @@ import "./Governance.sol";
 /// @author Matter Labs
 contract PriorityQueue {
 
-    /// @notice Franklin contract address
+    /// @notice Rollup contract address
     address internal franklinAddress;
 
     /// @notice Governance contract
@@ -28,10 +28,10 @@ contract PriorityQueue {
     /// @notice Ethereum address bytes length
     uint8 constant ETH_ADDR_BYTES = 20;
 
-    /// @notice Franklin account id bytes length
+    /// @notice Rollup account id bytes length
     uint8 constant ACC_NUM_BYTES = 3;
 
-    /// @notice Franklin nonce bytes length
+    /// @notice Rollup nonce bytes length
     uint8 constant NONCE_BYTES = 4;
 
     /// @notice Franklin chain address length
@@ -79,7 +79,7 @@ contract PriorityQueue {
     uint64 public totalOpenPriorityRequests;
 
     /// @notice Total number of committed requests.
-    /// @dev Used in checks: if the request matches the operation on Franklin contract and if provided number of requests is not too big
+    /// @dev Used in checks: if the request matches the operation on Rollup contract and if provided number of requests is not too big
     uint64 public totalCommittedPriorityRequests;
 
     /// @notice Constructs PriorityQueue contract
@@ -88,8 +88,8 @@ contract PriorityQueue {
         governance = Governance(_governanceAddress);
     }
 
-    /// @notice Sets franklin address if it has not been set before
-    /// @param _franklinAddress Address of the Franklin contract
+    /// @notice Sets rollup address if it has not been set before
+    /// @param _franklinAddress Address of the Rollup contract
     function setFranklinAddress(address _franklinAddress) external {
         // Its possible to set franklin contract address only if it has not been setted before
         require(
@@ -104,7 +104,7 @@ contract PriorityQueue {
 
     /// @notice Saves priority request in storage
     /// @dev Calculates expiration block for request, store this request and emit NewPriorityRequest event
-    /// @param _opType Franklin operation type
+    /// @param _opType Rollup operation type
     /// @param _fee Validators' fee
     /// @param _pubData Operation pubdata
     function addPriorityRequest(
@@ -166,7 +166,7 @@ contract PriorityQueue {
         }
     }
 
-    /// @notice Compares Franklin operation with corresponding priority requests' operation
+    /// @notice Compares Rollup operation with corresponding priority requests' operation
     /// @param _opType Operation type
     /// @param _pubData Operation pub data
     /// @param _id - Request id
@@ -220,7 +220,7 @@ contract PriorityQueue {
             priorityRequests[firstPriorityRequestId].expirationBlock != 0;
     }
 
-    /// @notice Check if the sender is franklin contract
+    /// @notice Check if the sender is rollup contract
     function requireFranklin() internal view {
         require(
             msg.sender == franklinAddress,

--- a/contracts/contracts/PriorityQueue.sol
+++ b/contracts/contracts/PriorityQueue.sol
@@ -7,8 +7,8 @@ import "./Governance.sol";
 /// @author Matter Labs
 contract PriorityQueue {
 
-    /// @notice Rollup contract address
-    address internal rollupAddress;
+    /// @notice Franklin contract address
+    address internal franklinAddress;
 
     /// @notice Governance contract
     Governance internal governance;
@@ -28,13 +28,13 @@ contract PriorityQueue {
     /// @notice Ethereum address bytes length
     uint8 constant ETH_ADDR_BYTES = 20;
 
-    /// @notice Rollup account id bytes length
+    /// @notice Franklin account id bytes length
     uint8 constant ACC_NUM_BYTES = 3;
 
-    /// @notice Rollup nonce bytes length
+    /// @notice Franklin nonce bytes length
     uint8 constant NONCE_BYTES = 4;
 
-    /// @notice Rollup chain address length
+    /// @notice Franklin chain address length
     uint8 constant PUBKEY_HASH_BYTES = 20;
 
     /// @notice Signature (for example full exit signature) length
@@ -79,7 +79,7 @@ contract PriorityQueue {
     uint64 public totalOpenPriorityRequests;
 
     /// @notice Total number of committed requests.
-    /// @dev Used in checks: if the request matches the operation on Rollup contract and if provided number of requests is not too big
+    /// @dev Used in checks: if the request matches the operation on Franklin contract and if provided number of requests is not too big
     uint64 public totalCommittedPriorityRequests;
 
     /// @notice Constructs PriorityQueue contract
@@ -88,23 +88,23 @@ contract PriorityQueue {
         governance = Governance(_governanceAddress);
     }
 
-    /// @notice Sets rollup address if it has not been set before
-    /// @param _rollupAddress Address of the Rollup contract
-    function setRollupAddress(address _rollupAddress) external {
-        // Its possible to set rollup contract address only if it has not been setted before
+    /// @notice Sets franklin address if it has not been set before
+    /// @param _franklinAddress Address of the Franklin contract
+    function setFranklinAddress(address _franklinAddress) external {
+        // Its possible to set franklin contract address only if it has not been setted before
         require(
-            rollupAddress == address(0),
+            franklinAddress == address(0),
             "pcs11"
-        ); // pcs11 - rollup address is already setted
+        ); // pcs11 - franklin address is already setted
         // Check for governor
         governance.requireGovernor(msg.sender);
-        // Set rollup address
-        rollupAddress = _rollupAddress;
+        // Set franklin address
+        franklinAddress = _franklinAddress;
     }
 
     /// @notice Saves priority request in storage
     /// @dev Calculates expiration block for request, store this request and emit NewPriorityRequest event
-    /// @param _opType Rollup operation type
+    /// @param _opType Franklin operation type
     /// @param _fee Validators' fee
     /// @param _pubData Operation pubdata
     function addPriorityRequest(
@@ -112,7 +112,7 @@ contract PriorityQueue {
         uint256 _fee,
         bytes calldata _pubData
     ) external {
-        requireRollup();
+        requireFranklin();
         // Expiration block is: current block number + priority expiration delta
         uint256 expirationBlock = block.number + PRIORITY_EXPIRATION;
 
@@ -138,7 +138,7 @@ contract PriorityQueue {
     /// @param _number The number of requests to process
     /// @return validators fee
     function collectValidatorsFeeAndDeleteRequests(uint64 _number) external returns (uint256) {
-        requireRollup();
+        requireFranklin();
         require(
             _number <= totalOpenPriorityRequests,
             "pcs21"
@@ -166,7 +166,7 @@ contract PriorityQueue {
         }
     }
 
-    /// @notice Compares Rollup operation with corresponding priority requests' operation
+    /// @notice Compares Franklin operation with corresponding priority requests' operation
     /// @param _opType Operation type
     /// @param _pubData Operation pub data
     /// @param _id - Request id
@@ -200,14 +200,14 @@ contract PriorityQueue {
     /// @notice Increases committed requests count by provided number
     /// @param _number Number of requests
     function increaseCommittedRequestsNumber(uint64 _number) external {
-        requireRollup();
+        requireFranklin();
         totalCommittedPriorityRequests += _number;
     }
 
     /// @notice Decreases committed requests count by provided number
     /// @param _number Number of requests
     function decreaseCommittedRequestsNumber(uint64 _number) external {
-        requireRollup();
+        requireFranklin();
         totalCommittedPriorityRequests -= _number;
     }
 
@@ -220,11 +220,11 @@ contract PriorityQueue {
             priorityRequests[firstPriorityRequestId].expirationBlock != 0;
     }
 
-    /// @notice Check if the sender is rollup contract
-    function requireRollup() internal view {
+    /// @notice Check if the sender is franklin contract
+    function requireFranklin() internal view {
         require(
-            msg.sender == rollupAddress,
+            msg.sender == franklinAddress,
             "prn11"
-        ); // prn11 - only by rollup
+        ); // prn11 - only by franklin
     }
 }

--- a/contracts/scripts/testnet-deploy.ts
+++ b/contracts/scripts/testnet-deploy.ts
@@ -42,7 +42,7 @@ async function main() {
     let franklinAddress      = process.env.CONTRACT_ADDR;
 
     let governanceConstructorArgs    = [ wallet.address ];
-    let priorityQueueConstructorArgs = [ wallet.address ];
+    let priorityQueueConstructorArgs = [ governanceAddress ];
     let verifierConstructorArgs      = [];
     let franklinConstructorArgs      = [
         governanceAddress,

--- a/contracts/src.ts/deploy.ts
+++ b/contracts/src.ts/deploy.ts
@@ -160,7 +160,7 @@ export async function deployFranklin(
         console.log(`CONTRACT_ADDR=${contract.address}`);
 
         const priorityQueueContract = new ethers.Contract(priorityQueueAddress, priorityQueueContractCode.interface, wallet);
-        await (await priorityQueueContract.changeFranklinAddress(contract.address)).wait();
+        await (await priorityQueueContract.setRollupAddress(contract.address)).wait();
         return contract;
     } catch (err) {
         console.log("Franklin deploy error:" + err);

--- a/contracts/src.ts/deploy.ts
+++ b/contracts/src.ts/deploy.ts
@@ -160,7 +160,7 @@ export async function deployFranklin(
         console.log(`CONTRACT_ADDR=${contract.address}`);
 
         const priorityQueueContract = new ethers.Contract(priorityQueueAddress, priorityQueueContractCode.interface, wallet);
-        await (await priorityQueueContract.setRollupAddress(contract.address)).wait();
+        await (await priorityQueueContract.setFranklinAddress(contract.address)).wait();
         return contract;
     } catch (err) {
         console.log("Franklin deploy error:" + err);


### PR DESCRIPTION
- In _PriorityQueue_ removed owner (now the governor has his duties). The governance contract is set in the _PriorityQueue_ contract in the `constructor`. Upon completion of the _PriorityQueue_ setup by assigning the address of the rollup contract in `setFranklinAddress`, the check that the msg.sender is the governor occurs
- `requireGovernor(address _address)` accepts address that must be a msg.sender. Made for ease of external call (in other contracts)
- removed unused requireValidTokenId function from Governance contract
