### PR TITLE
Remove send trait from EthereumAccount

### DIFF
--- a/core/lib/eth_signer/src/json_rpc_signer.rs
+++ b/core/lib/eth_signer/src/json_rpc_signer.rs
@@ -40,7 +40,7 @@ pub struct JsonRpcSigner {
     signer_type: Option<SignerType>,
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl EthereumSigner for JsonRpcSigner {
     /// The sign method calculates an Ethereum specific signature with:
     /// checks if the server adds a prefix if not then adds

--- a/core/lib/eth_signer/src/lib.rs
+++ b/core/lib/eth_signer/src/lib.rs
@@ -15,7 +15,7 @@ pub mod json_rpc_signer;
 pub mod pk_signer;
 pub mod raw_ethereum_tx;
 
-#[async_trait]
+#[async_trait(?Send)]
 pub trait EthereumSigner {
     async fn sign_message(&self, message: &[u8]) -> Result<TxEthSignature, SignerError>;
     async fn sign_transaction(&self, raw_tx: RawTransaction) -> Result<Vec<u8>, SignerError>;

--- a/core/lib/eth_signer/src/pk_signer.rs
+++ b/core/lib/eth_signer/src/pk_signer.rs
@@ -23,7 +23,7 @@ impl PrivateKeySigner {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl EthereumSigner for PrivateKeySigner {
     /// Get Ethereum address that matches the private key.
     async fn get_address(&self) -> Result<Address, SignerError> {


### PR DESCRIPTION
While implementing the `zksync-rs` crate into our software we are running into errors due to the `Send` trait.

It seems this was added as an unexpected side-effect of using `async_trait`

This PR Removes the trait since it looks like its not required.