### PR TITLE
switch order of salt creation to match gnosis safe

### DIFF
--- a/contracts/contracts/ZkSync.sol
+++ b/contracts/contracts/ZkSync.sol
@@ -610,7 +610,7 @@ contract ZkSync is UpgradeableMaster, Storage, Config, Events, ReentrancyGuard {
         (offset, creatorAddress) = Bytes.readAddress(_args, offset);
         (offset, saltArg) = Bytes.readBytes32(_args, offset);
         (offset, codeHash) = Bytes.readBytes32(_args, offset);
-        bytes32 salt = keccak256(abi.encodePacked(saltArg, _newPkHash));
+        bytes32 salt = keccak256(abi.encodePacked(saltArg, uint256(uint160(_newPkHash))));
         address recoveredAddress = address(uint160(uint256(keccak256(abi.encodePacked(bytes1(0xff), creatorAddress, salt, codeHash)))));
         return recoveredAddress == _ethAddress && _nonce == 0;
     }

--- a/contracts/contracts/ZkSync.sol
+++ b/contracts/contracts/ZkSync.sol
@@ -610,7 +610,7 @@ contract ZkSync is UpgradeableMaster, Storage, Config, Events, ReentrancyGuard {
         (offset, creatorAddress) = Bytes.readAddress(_args, offset);
         (offset, saltArg) = Bytes.readBytes32(_args, offset);
         (offset, codeHash) = Bytes.readBytes32(_args, offset);
-        bytes32 salt = keccak256(abi.encodePacked(_newPkHash,saltArg));
+        bytes32 salt = keccak256(abi.encodePacked(saltArg, _newPkHash));
         address recoveredAddress = address(uint160(uint256(keccak256(abi.encodePacked(bytes1(0xff), creatorAddress, salt, codeHash)))));
         return recoveredAddress == _ethAddress && _nonce == 0;
     }

--- a/core/lib/types/src/tx/change_pubkey.rs
+++ b/core/lib/types/src/tx/change_pubkey.rs
@@ -203,8 +203,8 @@ impl ChangePubKey {
             } => {
                 let salt = {
                     let mut bytes = Vec::new();
-                    bytes.extend_from_slice(&self.new_pk_hash.data);
                     bytes.extend_from_slice(salt_arg.as_bytes());
+                    bytes.extend_from_slice(&self.new_pk_hash.data);
                     bytes.keccak256()
                 };
 

--- a/core/lib/types/src/tx/change_pubkey.rs
+++ b/core/lib/types/src/tx/change_pubkey.rs
@@ -204,6 +204,7 @@ impl ChangePubKey {
                 let salt = {
                     let mut bytes = Vec::new();
                     bytes.extend_from_slice(salt_arg.as_bytes());
+                    bytes.extend_from_slice(&[0u8; 12]);
                     bytes.extend_from_slice(&self.new_pk_hash.data);
                     bytes.keccak256()
                 };

--- a/sdk/zksync.js/src/utils.ts
+++ b/sdk/zksync.js/src/utils.ts
@@ -456,7 +456,7 @@ export function calculateCreate2WalletAddressAndSalt(
 
     // CREATE2 salt
     const salt = ethers.utils.keccak256(
-        ethers.utils.concat([ethers.utils.arrayify(pubkeyHashHex), additionalSaltArgument])
+        ethers.utils.concat([additionalSaltArgument,ethers.utils.arrayify(pubkeyHashHex)])
     );
 
     // Address according to CREATE2 specification

--- a/sdk/zksync.js/src/utils.ts
+++ b/sdk/zksync.js/src/utils.ts
@@ -447,7 +447,7 @@ export function calculateCreate2WalletAddressAndSalt(
     syncPubkeyHash: string,
     create2Data: Create2WalletData
 ): { salt: string; address: string } {
-    const pubkeyHashHex = syncPubkeyHash.replace("sync:", "0x");
+    const pubkeyHashHex = syncPubkeyHash.replace("sync:", "0x000000000000000000000000");
 
     const additionalSaltArgument = ethers.utils.arrayify(create2Data.saltArg);
     if (additionalSaltArgument.length !== 32) {


### PR DESCRIPTION
At the moment the gnosis safe simply uses exactly the opposite order. 


```js
// gnosis safe
bytes32 salt = keccak256(abi.encodePacked(keccak256(initializer), saltNonce));
```

https://github.com/gnosis/safe-contracts/blob/development/contracts/proxies/GnosisSafeProxyFactory.sol#L47

So If we could have the saltArg as first argument, this would work with the gnosis safe.
Do you see a chance switching the order here:


```js
// zksync
bytes32 salt = keccak256(abi.encodePacked(_newPkHash,saltArg)); 
```
https://github.com/matter-labs/zksync/blob/create2-deployment/contracts/contracts/ZkSync.sol#L613


See https://github.com/matter-labs/zksync/issues/256