### PR TITLE
Fix Environment Variable GATEKEEPER_ADDR -> UPGRADE_GATEKEEPER_ADDR

### DIFF
--- a/infrastructure/zk/src/contract.ts
+++ b/infrastructure/zk/src/contract.ts
@@ -112,7 +112,7 @@ export async function deploy() {
         'GOVERNANCE_ADDR',
         'CONTRACT_ADDR',
         'VERIFIER_ADDR',
-        'GATEKEEPER_ADDR',
+        'UPGRADE_GATEKEEPER_ADDR',
         'DEPLOY_FACTORY_ADDR',
         'GENESIS_TX_HASH'
     ];


### PR DESCRIPTION
I found some kind of mistaking about the following environment variable.
https://github.com/matter-labs/zksync/blob/master/infrastructure/zk/src/contract.ts#L115

It seems like there is no `GATEKEEPER_ADDR`.
<img width="505" alt="update" src="https://user-images.githubusercontent.com/39494661/104288402-17ef1100-54fb-11eb-9713-615ed3844788.png">

And the environment built by the [document](https://github.com/matter-labs/zksync/blob/master/docs/setup-dev.md), the `deploy.log` is following.
```
ubuntu@ip-x-x-x-x:~/zksync$ cat deploy.log
yarn run v1.22.5
$ yarn workspace franklin-contracts deploy-no-build
$ ts-node scripts/deploy.ts
Using gas price: 1.0 gwei
Deploying for governor: 0x52312AD6f01657413b2eaE9287f6B9ADaD93D5FE
Deploying zkSync target
CONTRACT_TARGET_ADDR=0x5E6D086F5eC079ADFF4FB3774CDf3e8D6a34F7E9
zkSync target deployed, gasUsed: 5033292, eth spent: 0.005033292
Deploying verifier target
VERIFIER_TARGET_ADDR=0x572b9410D9a14Fa729F3af92cB83A07aaA472dE0
Verifier target deployed, gasUsed: 3821017, eth spent: 0.003821017
Deploying governance target
GOVERNANCE_TARGET_ADDR=0xc56E79CAA94C96DE01eF36560ac215cC7A4F0F47
Governance target deployed, gasUsed: 487436, eth spent: 0.000487436
DEPLOY_FACTORY_ADDR=0x70a0F165d6f8054d0d0CF8dFd4DD2005f0AF6B55
GOVERNANCE_ADDR=0xF383bd74c2F80Eb03e82Bf7F0aCb3e869dBfA324
CONTRACT_ADDR=0xBa2fE1C0669B28fbA1537DE8F893B356A41701bB
VERIFIER_ADDR=0x9EE6D7616Deb793FBf71103026DE427AB27161A4
UPGRADE_GATEKEEPER_ADDR=0x55f6Eb643438a7C116E818F8104edA87c3F08D0d
GENESIS_TX_HASH=0x42e2203adf9aa9aae55a67d52181fb2a48f94bf7a0faa0bff6cc039e202c430f
Deploy finished, gasUsed: 3725795, eth spent: 0.003725795
Done in 21.75s.
```

Thank you.
