### PR TITLE
fix(cli): fix an error message

### DIFF
--- a/infrastructure/zk/src/env.ts
+++ b/infrastructure/zk/src/env.ts
@@ -36,7 +36,7 @@ export function set(env: string) {
         throw new Error(envFile + ' not found');
     }
     if (!fs.existsSync(envDir)) {
-        throw new Error(envFile + ' not found');
+        throw new Error(envDir + ' not found');
     }
 
     fs.writeFileSync('etc/env/current', env);


### PR DESCRIPTION
fix an error message.

```bash
$ zk env docker
Error: etc/env/docker.env not found

❯ ls -al etc/env/docker.env
-rw-rw-r-- 1 serinuntius 360  2月  6 10:31 etc/env/docker.env
```

I actually encountered this error message. But this message is not correct.
