### PR TITLE
fix: _proc_macro_hack_xxx in the root 

### DIFF
--- a/core/bin/zksync_api/Cargo.toml
+++ b/core/bin/zksync_api/Cargo.toml
@@ -63,7 +63,7 @@ reqwest = { version = "0.10", features = ["blocking", "json"] }
 tiny-keccak = "1.4.2"
 async-trait = "0.1"
 jsonwebtoken = "7"
-metrics = "=0.13.0-alpha.8"
+metrics = "=0.14.2"
 lru-cache = "0.1.2"
 once_cell = "1.4"
 regex = "1"

--- a/core/bin/zksync_core/Cargo.toml
+++ b/core/bin/zksync_core/Cargo.toml
@@ -27,7 +27,7 @@ ethabi = "12.0.0"
 web3 = "0.13.0"
 serde = "1.0.90"
 serde_json = "1.0.0"
-metrics = "=0.13.0-alpha.8"
+metrics = "=0.14.2"
 itertools = "0.9.0"
 
 vlog = { path = "../../lib/vlog", version = "1.0" }

--- a/core/bin/zksync_eth_sender/Cargo.toml
+++ b/core/bin/zksync_eth_sender/Cargo.toml
@@ -26,7 +26,7 @@ ethabi = "12.0.0"
 web3 = "0.13.0"
 serde = "1.0.90"
 serde_json = "1.0.0"
-metrics = "=0.13.0-alpha.8"
+metrics = "=0.14.2"
 vlog = { path = "../../lib/vlog", version = "1.0" }
 
 tokio = { version = "0.2", features = ["full"] }

--- a/core/bin/zksync_witness_generator/Cargo.toml
+++ b/core/bin/zksync_witness_generator/Cargo.toml
@@ -27,7 +27,7 @@ tracing = "0.1.22"
 
 serde = "1.0.90"
 serde_json = "1.0.0"
-metrics = "=0.13.0-alpha.8"
+metrics = "=0.14.2"
 tokio = { version = "0.2", features = ["full"] }
 futures = "0.3"
 actix-rt = "1.1.1"

--- a/core/lib/eth_client/Cargo.toml
+++ b/core/lib/eth_client/Cargo.toml
@@ -24,4 +24,4 @@ hex = "0.4"
 
 anyhow = "1.0"
 tokio = { version = "0.2", features = ["full"] }
-metrics = "=0.13.0-alpha.8"
+metrics = "=0.14.2"

--- a/core/lib/prometheus_exporter/Cargo.toml
+++ b/core/lib/prometheus_exporter/Cargo.toml
@@ -23,7 +23,7 @@ futures = "0.3"
 ctrlc = { version = "3.1", features = ["termination"] }
 anyhow = "1.0"
 
-metrics = "=0.13.0-alpha.8"
+metrics = "=0.14.2"
 metrics-exporter-prometheus = "=0.1.0-alpha.7"
 metrics-macros = "=0.1.0-alpha.5"
 metrics-util = "=0.4.0-alpha.6"

--- a/core/lib/state/Cargo.toml
+++ b/core/lib/state/Cargo.toml
@@ -17,7 +17,7 @@ zksync_types = { path = "../types", version = "1.0" }
 num = { version = "0.3.1", features = ["serde"] }
 vlog = { path = "../../lib/vlog", version = "1.0" }
 anyhow = "1.0"
-metrics = "=0.13.0-alpha.8"
+metrics = "=0.14.2"
 serde_json = "1.0"
 
 

--- a/core/lib/storage/Cargo.toml
+++ b/core/lib/storage/Cargo.toml
@@ -29,7 +29,7 @@ anyhow = "1.0"
 lazy_static = "1.4.0"
 itertools = "0.8"
 hex = "0.4"
-metrics = "=0.13.0-alpha.8"
+metrics = "=0.14.2"
 parity-crypto = { version = "0.6.2", features = ["publickey"] }
 
 vlog = { path = "../../lib/vlog", version = "1.0" }


### PR DESCRIPTION
metrics: drop proc-macro-hack usage

```shell
Checking metrics v0.13.0-alpha.8
error[E0432]: unresolved import `metrics_macros::_proc_macro_hack_register_counter`
   --> /Users/kilmas/.cargo/registry/src/github.com-1ecc6299db9ec823/metrics-0.13.0-alpha.8/src/lib.rs:199:9
    |
199 | pub use metrics_macros::register_counter;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `_proc_macro_hack_register_counter` in the root

error[E0432]: unresolved import `metrics_macros::_proc_macro_hack_register_gauge`
   --> /Users/kilmas/.cargo/registry/src/github.com-1ecc6299db9ec823/metrics-0.13.0-alpha.8/src/lib.rs:242:9
    |
242 | pub use metrics_macros::register_gauge;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `_proc_macro_hack_register_gauge` in the root

error[E0432]: unresolved import `metrics_macros::_proc_macro_hack_register_histogram`
   --> /Users/kilmas/.cargo/registry/src/github.com-1ecc6299db9ec823/metrics-0.13.0-alpha.8/src/lib.rs:285:9
    |
285 | pub use metrics_macros::register_histogram;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `_proc_macro_hack_register_histogram` in the root

error[E0432]: unresolved import `metrics_macros::_proc_macro_hack_increment`
   --> /Users/kilmas/.cargo/registry/src/github.com-1ecc6299db9ec823/metrics-0.13.0-alpha.8/src/lib.rs:319:9
    |
319 | pub use metrics_macros::increment;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^ no `_proc_macro_hack_increment` in the root

error[E0432]: unresolved import `metrics_macros::_proc_macro_hack_counter`
   --> /Users/kilmas/.cargo/registry/src/github.com-1ecc6299db9ec823/metrics-0.13.0-alpha.8/src/lib.rs:353:9
    |
353 | pub use metrics_macros::counter;
    |         ^^^^^^^^^^^^^^^^^^^^^^^ no `_proc_macro_hack_counter` in the root

error[E0432]: unresolved import `metrics_macros::_proc_macro_hack_gauge`
   --> /Users/kilmas/.cargo/registry/src/github.com-1ecc6299db9ec823/metrics-0.13.0-alpha.8/src/lib.rs:387:9
    |
387 | pub use metrics_macros::gauge;
    |         ^^^^^^^^^^^^^^^^^^^^^ no `_proc_macro_hack_gauge` in the root

error[E0432]: unresolved import `metrics_macros::_proc_macro_hack_histogram`
   --> /Users/kilmas/.cargo/registry/src/github.com-1ecc6299db9ec823/metrics-0.13.0-alpha.8/src/lib.rs:435:9
    |
435 | pub use metrics_macros::histogram;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^ no `_proc_macro_hack_histogram` in the root

error: aborting due to 7 previous errors

For more information about this error, try `rustc --explain E0432`.
error: could not compile `metrics`
```

Enviroment: mac pro m1
```
Software:
    System Software Overview:
      System Version: macOS 11.2.1 (20D74)
      Kernel Version: Darwin 20.3.0
      Boot Volume: Macintosh HD
      Boot Mode: Normal
      Computer Name: kilmas的MacBook Pro
      User Name: kilmas (kilmas)
      Secure Virtual Memory: Enabled
      System Integrity Protection: Enabled
      Time since boot: 6 days 16:42
ProductName:	macOS 
ProductVersion:	11.2.1
BuildVersion:	20D74
```