### PR TITLE
a fix in the batch fee check

### DIFF
--- a/core/bin/zksync_api/src/api_server/tx_sender.rs
+++ b/core/bin/zksync_api/src/api_server/tx_sender.rs
@@ -322,6 +322,8 @@ impl TxSender {
             let tx_fee_info = tx.tx.get_fee_info();
 
             if let Some((tx_type, token, address, provided_fee)) = tx_fee_info {
+                // Save the transaction type before moving on to the next one, otherwise
+                // the total fee won't get affected by it.
                 transaction_types.push((tx_type, address));
 
                 if provided_fee == BigUint::zero() {

--- a/core/bin/zksync_api/src/api_server/tx_sender.rs
+++ b/core/bin/zksync_api/src/api_server/tx_sender.rs
@@ -322,14 +322,14 @@ impl TxSender {
             let tx_fee_info = tx.tx.get_fee_info();
 
             if let Some((tx_type, token, address, provided_fee)) = tx_fee_info {
+                transaction_types.push((tx_type, address));
+
                 if provided_fee == BigUint::zero() {
                     continue;
                 }
                 let fee_allowed =
                     Self::token_allowed_for_fees(self.ticker_requests.clone(), token.clone())
                         .await?;
-
-                transaction_types.push((tx_type, address));
 
                 // In batches, transactions with non-popular token are allowed to be included, but should not
                 // used to pay fees. Fees must be covered by some more common token.

--- a/core/tests/ts-tests/tests/main.test.ts
+++ b/core/tests/ts-tests/tests/main.test.ts
@@ -110,6 +110,7 @@ describe(`ZkSync integration tests (token: ${token}, transport: ${transport})`, 
         await tester.testBatch(alice, bob, token, TX_AMOUNT);
         await tester.testIgnoredBatch(alice, bob, token, TX_AMOUNT);
         await tester.testRejectedBatch(alice, bob, token, TX_AMOUNT);
+        await tester.testInvalidFeeBatch(alice, bob, token, TX_AMOUNT);
     });
 
     step('should test batch-builder', async () => {

--- a/core/tests/ts-tests/tests/transfer.ts
+++ b/core/tests/ts-tests/tests/transfer.ts
@@ -11,6 +11,7 @@ declare module './tester' {
         testBatch(from: Wallet, to: Wallet, token: TokenLike, amount: BigNumber): Promise<void>;
         testIgnoredBatch(from: Wallet, to: Wallet, token: TokenLike, amount: BigNumber): Promise<void>;
         testRejectedBatch(from: Wallet, to: Wallet, token: TokenLike, amount: BigNumber): Promise<void>;
+        testInvalidFeeBatch(from: Wallet, to: Wallet, token: TokenLike, amount: BigNumber): Promise<void>;
     }
 }
 
@@ -132,6 +133,43 @@ Tester.prototype.testRejectedBatch = async function (
     let thrown = true;
     try {
         const handles = await sender.syncMultiTransfer([{ ...tx }, { ...tx }]);
+        for (const handle of handles) {
+            await handle.awaitVerifyReceipt();
+        }
+        thrown = false; // this line should be unreachable
+    } catch (e) {
+        expect(e.jrpcError.message).to.equal('Transactions batch summary fee is too low');
+    }
+    expect(thrown, 'Batch should have failed').to.be.true;
+};
+
+// Checks that the server takes into account all transactions from the batch when calculating
+// the fee.
+Tester.prototype.testInvalidFeeBatch = async function (
+    sender: Wallet,
+    receiver: Wallet,
+    token: types.TokenLike,
+    amount: BigNumber
+) {
+    // Ignore the second transfer.
+    const fee = await this.syncProvider.getTransactionsBatchFee(['Transfer'], [receiver.address()], token);
+
+    const tx_with_fee = {
+        to: receiver.address(),
+        token,
+        amount,
+        fee
+    };
+    const tx_without_fee = {
+        to: receiver.address(),
+        token,
+        amount,
+        fee: 0
+    };
+
+    let thrown = true;
+    try {
+        const handles = await sender.syncMultiTransfer([tx_without_fee, tx_with_fee]);
         for (const handle of handles) {
             await handle.awaitVerifyReceipt();
         }


### PR DESCRIPTION
It is possible to not pay fees for transactions in a batch, for which provided fees are zero.
How to do it:
- Get a fee amount for a batch with one Transfer transaction.
- Send a batch with two Transfer transactions. The fee of first transaction is zero, the fee of second transaction is as above.