### PR TITLE
Documentation fix: sql-cli version 0.2.0 -> 0.5.2 …

### DIFF
--- a/docs/setup-dev.md
+++ b/docs/setup-dev.md
@@ -133,7 +133,7 @@ sudo apt install build-essential
 Also, we need `[sqlx](https://github.com/launchbadge/sqlx)` CLI (it is used to generate database wrappers):
 
 ```bash
-cargo install --version=0.2.0 sqlx-cli
+cargo install --version=0.5.2 sqlx-cli
 ```
 
 If you face an error `Could not find directory of OpenSSL installation`, then you should do the following.


### PR DESCRIPTION
sql-cli-0.2.0 doesn't work any more because a dependency got yanked, substitute 0.5.2 which is used elsewhere in the project