### PR TITLE
Handle breaking update to wasm-pack

### DIFF
--- a/sdk/zksync-crypto/build.sh
+++ b/sdk/zksync-crypto/build.sh
@@ -5,7 +5,7 @@ set -e
 BG_ASM=dist/zksync-crypto-bundler_bg_asm.js
 ASM=dist/zksync-crypto-bundler_asm.js
 
-which wasm-pack || cargo install --version 0.10.1 wasm-pack
+which wasm-pack || cargo install --version 0.10.1 wasm-pack #Dec 16th update to wasm-pack (v0.10.2) breaks zk init
 
 # pack for bundler (!note this verion is used in the pkg.browser field)
 wasm-pack build --release --target=bundler --out-name=zksync-crypto-bundler --out-dir=dist

--- a/sdk/zksync-crypto/build.sh
+++ b/sdk/zksync-crypto/build.sh
@@ -5,7 +5,7 @@ set -e
 BG_ASM=dist/zksync-crypto-bundler_bg_asm.js
 ASM=dist/zksync-crypto-bundler_asm.js
 
-which wasm-pack || cargo install wasm-pack
+which wasm-pack || cargo install --version 0.10.1 wasm-pack
 
 # pack for bundler (!note this verion is used in the pkg.browser field)
 wasm-pack build --release --target=bundler --out-name=zksync-crypto-bundler --out-dir=dist


### PR DESCRIPTION
Recent (Dec 16th) update of `wasm-pack` to v0.10.2 breaks `zk init` process. Adding wasm-pack v0.10.1 to Cargo.toml lead to other errors. This is a simple, temporary until a more robust fix is made available. 