### PR TITLE
Reduce the number of constraints in verifying musig signature.

### DIFF
--- a/core/lib/circuit/src/signature.rs
+++ b/core/lib/circuit/src/signature.rs
@@ -292,7 +292,7 @@ pub fn is_rescue_signature_verified<E: RescueEngine + JubjubEngine, CS: Constrai
         let mut pk_x_serialized = signature
             .pk
             .get_x()
-            .into_bits_le_strict(cs.namespace(|| "pk_x_bits into bits strict"))?;
+            .into_bits_le(cs.namespace(|| "pk_x_bits into bits strict"))?;
 
         assert_eq!(pk_x_serialized.len(), FR_BIT_WIDTH);
 
@@ -307,7 +307,7 @@ pub fn is_rescue_signature_verified<E: RescueEngine + JubjubEngine, CS: Constrai
         let mut r_x_serialized = signature
             .r
             .get_x()
-            .into_bits_le_strict(cs.namespace(|| "r_x_bits into bits strict"))?;
+            .into_bits_le(cs.namespace(|| "r_x_bits into bits strict"))?;
 
         assert_eq!(r_x_serialized.len(), FR_BIT_WIDTH);
 


### PR DESCRIPTION
Since zkSync use AltJubjubBn256 curve in the musig, and the base field is the scalar field of the BN256 curve, so when convert the `x` coordinate of a point in AltJubjubBn256 into bits vector in the circuit,  it's not necessary to use `into_bits_le_strict`.