### PR TITLE
Fix dummy-prover becoming an orphan process

### DIFF
--- a/infrastructure/zk/src/dummy-prover.ts
+++ b/infrastructure/zk/src/dummy-prover.ts
@@ -12,7 +12,11 @@ async function performRedeployment() {
 }
 
 export async function run() {
-    await utils.spawn('cargo run --release --bin dummy_prover dummy-prover-instance');
+    const child = utils.background('cargo run --release --bin dummy_prover dummy-prover-instance');
+
+    process.on('SIGINT', () => {
+        child.kill('SIGINT');
+    });
 }
 
 export async function status() {


### PR DESCRIPTION
Currently, using a `dummy-prover` for development creates an orphan process, which is unable to stop in a normal way (through `CTRL+C`).

This PR fixes the issue by handling the SIGINT in the same way as the normal `prover`.