### PR TITLE
Fix locks in conflicting orders in core/tests/test_account

### DIFF
--- a/core/tests/test_account/src/lib.rs
+++ b/core/tests/test_account/src/lib.rs
@@ -167,12 +167,12 @@ impl ZkSyncAccount {
         nonce: Option<Nonce>,
         increment_nonce: bool,
     ) -> (MintNFT, Option<PackedEthSignature>) {
+        let account_id = self
+            .get_account_id()
+            .expect("can't sign tx without account id");
         let mut stored_nonce = self.nonce.lock().unwrap();
         let mint_nft = MintNFT::new_signed(
-            self.account_id
-                .lock()
-                .unwrap()
-                .expect("can't sign tx without account id"),
+            account_id,
             self.address,
             content_hash,
             *recipient,
@@ -212,12 +212,12 @@ impl ZkSyncAccount {
         increment_nonce: bool,
         time_range: TimeRange,
     ) -> (WithdrawNFT, Option<PackedEthSignature>) {
+        let account_id = self
+            .get_account_id()
+            .expect("can't sign tx without account id");
         let mut stored_nonce = self.nonce.lock().unwrap();
         let withdraw_nft = WithdrawNFT::new_signed(
-            self.account_id
-                .lock()
-                .unwrap()
-                .expect("can't sign tx without account id"),
+            account_id,
             self.address,
             *recipient,
             token,
@@ -259,10 +259,12 @@ impl ZkSyncAccount {
         increment_nonce: bool,
         time_range: TimeRange,
     ) -> Order {
+        let account_id = self
+            .get_account_id()
+            .expect("can't sign tx without account id");
         let mut stored_nonce = self.nonce.lock().unwrap();
         let order = Order::new_signed(
-            self.get_account_id()
-                .expect("can't sign tx without account id"),
+            account_id,
             *recipient,
             nonce.unwrap_or_else(|| *stored_nonce),
             token_sell,
@@ -292,10 +294,12 @@ impl ZkSyncAccount {
         fee_token_symbol: &str,
         fee: BigUint,
     ) -> (Swap, Option<PackedEthSignature>) {
+        let account_id = self
+            .get_account_id()
+            .expect("can't sign tx without account id");
         let mut stored_nonce = self.nonce.lock().unwrap();
         let swap = Swap::new_signed(
-            self.get_account_id()
-                .expect("can't sign tx without account id"),
+            account_id,
             self.address,
             nonce.unwrap_or_else(|| *stored_nonce),
             orders,
@@ -335,12 +339,12 @@ impl ZkSyncAccount {
         increment_nonce: bool,
         time_range: TimeRange,
     ) -> (Transfer, Option<PackedEthSignature>) {
+        let account_id = self
+            .get_account_id()
+            .expect("can't sign tx without account id");
         let mut stored_nonce = self.nonce.lock().unwrap();
         let transfer = Transfer::new_signed(
-            self.account_id
-                .lock()
-                .unwrap()
-                .expect("can't sign tx without account id"),
+            account_id,
             self.address,
             *to,
             token_id,
@@ -378,12 +382,12 @@ impl ZkSyncAccount {
         increment_nonce: bool,
         time_range: TimeRange,
     ) -> ForcedExit {
+        let account_id = self
+            .get_account_id()
+            .expect("can't sign tx without account id");
         let mut stored_nonce = self.nonce.lock().unwrap();
         let forced_exit = ForcedExit::new_signed(
-            self.account_id
-                .lock()
-                .unwrap()
-                .expect("can't sign tx without account id"),
+            account_id,
             *target,
             token_id,
             fee,
@@ -412,12 +416,12 @@ impl ZkSyncAccount {
         increment_nonce: bool,
         time_range: TimeRange,
     ) -> (Withdraw, Option<PackedEthSignature>) {
+        let account_id = self
+            .get_account_id()
+            .expect("can't sign tx without account id");
         let mut stored_nonce = self.nonce.lock().unwrap();
         let withdraw = Withdraw::new_signed(
-            self.account_id
-                .lock()
-                .unwrap()
-                .expect("can't sign tx without account id"),
+            account_id,
             self.address,
             *eth_address,
             token_id,
@@ -472,9 +476,7 @@ impl ZkSyncAccount {
         time_range: TimeRange,
     ) -> ChangePubKey {
         let account_id = self
-            .account_id
-            .lock()
-            .unwrap()
+            .get_account_id()
             .expect("can't sign tx withoud account id");
         let mut stored_nonce = self.nonce.lock().unwrap();
         let nonce = nonce.unwrap_or_else(|| *stored_nonce);


### PR DESCRIPTION
This may lead to deadlock if the conflicting locks order in different account
```
pub struct ZkSyncAccount {
    ...
    account_id: Mutex<Option<AccountId>>,
    nonce: Mutex<Nonce>,
}
```
`account_id` locked before `nonce` in `clone`:
https://github.com/matter-labs/zksync/blob/0d9b71ebc3b16abf667a9507859c7e34bb77a8d2/core/tests/test_account/src/lib.rs#L60-L61
`nonce` locked before `account_id` in 7 places, e.g., in `sign_mint_nft`:
https://github.com/matter-labs/zksync/blob/0d9b71ebc3b16abf667a9507859c7e34bb77a8d2/core/tests/test_account/src/lib.rs#L170-L175

Fix:
I follow the lock order as defined in struct `ZkSyncAccount` and lift `account_id` lock before `nonce`.
Besides, I use `get_account_id()` instead of `account_id.lock().unwrap()` to make code concise.


 
