### PR TITLE
Create2 deployment

### DIFF
--- a/bin/k8s-server-env-cm-from-env
+++ b/bin/k8s-server-env-cm-from-env
@@ -27,7 +27,7 @@ case $ZKSYNC_ENV in
     prod)
         update_configmap zksync
         ;;
-    stage | rinkeby | ropsten | breaking)
+    stage | rinkeby | ropsten | breaking | ropsten-beta)
         update_configmap $ZKSYNC_ENV
         ;;
     -h|--h)

--- a/core/bin/data_restore/src/rollup_ops.rs
+++ b/core/bin/data_restore/src/rollup_ops.rs
@@ -104,7 +104,7 @@ mod test {
     use crate::rollup_ops::RollupOpsBlock;
     use num::BigUint;
     use zksync_types::operations::ChangePubKeyOp;
-    use zksync_types::tx::{ChangePubKey, TxSignature};
+    use zksync_types::tx::{ChangePubKey, ChangePubKeyType, TxSignature};
     use zksync_types::{
         Close, CloseOp, Deposit, DepositOp, FullExit, FullExitOp, PubKeyHash, Transfer, TransferOp,
         TransferToNewOp, Withdraw, WithdrawOp, ZkSyncOp,
@@ -272,7 +272,7 @@ mod test {
             Default::default(),
             3,
             None,
-            None,
+            ChangePubKeyType::OnchainTransaction,
         );
         let op1 = ZkSyncOp::ChangePubKeyOffchain(Box::new(ChangePubKeyOp { tx, account_id: 11 }));
         let pub_data1 = op1.public_data();

--- a/core/bin/zksync_api/src/api_server/rpc_server/mod.rs
+++ b/core/bin/zksync_api/src/api_server/rpc_server/mod.rs
@@ -121,7 +121,9 @@ impl RpcApp {
         io.extend_with(self.to_delegate())
     }
 
+    #[allow(dead_code)]
     async fn token_info_from_id(&self, token_id: TokenId) -> Result<Token> {
+        #[allow(dead_code)]
         fn rpc_message(error: impl ToString) -> Error {
             Error {
                 code: RpcErrorCodes::Other.into(),
@@ -140,22 +142,24 @@ impl RpcApp {
     /// Returns a message that user has to sign to send the transaction.
     /// If the transaction doesn't need a message signature, returns `None`.
     /// If any error is encountered during the message generation, returns `jsonrpc_core::Error`.
-    async fn get_tx_info_message_to_sign(&self, tx: &ZkSyncTx) -> Result<Option<String>> {
-        match tx {
-            ZkSyncTx::Transfer(tx) => {
-                let token = self.token_info_from_id(tx.token).await?;
-                Ok(Some(
-                    tx.get_ethereum_sign_message(&token.symbol, token.decimals),
-                ))
-            }
-            ZkSyncTx::Withdraw(tx) => {
-                let token = self.token_info_from_id(tx.token).await?;
-                Ok(Some(
-                    tx.get_ethereum_sign_message(&token.symbol, token.decimals),
-                ))
-            }
-            _ => Ok(None),
-        }
+    async fn get_tx_info_message_to_sign(&self, _tx: &ZkSyncTx) -> Result<Option<String>> {
+        Ok(None)
+        // TODO: disbale 2fa for this branch
+        // match tx {
+        //     ZkSyncTx::Transfer(tx) => {
+        //         let token = self.token_info_from_id(tx.token).await?;
+        //         Ok(Some(
+        //             tx.get_ethereum_sign_message(&token.symbol, token.decimals),
+        //         ))
+        //     }
+        //     ZkSyncTx::Withdraw(tx) => {
+        //         let token = self.token_info_from_id(tx.token).await?;
+        //         Ok(Some(
+        //             tx.get_ethereum_sign_message(&token.symbol, token.decimals),
+        //         ))
+        //     }
+        //     _ => Ok(None),
+        // }
     }
 }
 

--- a/core/bin/zksync_api/src/signature_checker.rs
+++ b/core/bin/zksync_api/src/signature_checker.rs
@@ -15,7 +15,7 @@ use zksync_types::{tx::TxEthSignature, SignedZkSyncTx, ZkSyncTx};
 // Local uses
 use crate::{eth_checker::EthereumChecker, tx_error::TxAddError};
 use zksync_config::ConfigurationOptions;
-use zksync_types::tx::EthSignData;
+use zksync_types::tx::{ChangePubKeyType, EthSignData};
 use zksync_utils::panic_notify::ThreadPanicNotify;
 
 /// Wrapper on a `ZkSyncTx` which guarantees that
@@ -63,7 +63,10 @@ async fn verify_eth_signature(
 ) -> Result<(), TxAddError> {
     // Check if the tx is a `ChangePubKey` operation without an Ethereum signature.
     if let ZkSyncTx::ChangePubKey(change_pk) = &request.tx {
-        if change_pk.eth_signature.is_none() {
+        if matches!(
+            change_pk.change_pubkey_type,
+            ChangePubKeyType::OnchainTransaction
+        ) {
             // Check that user is allowed to perform this operation.
             let is_authorized = eth_checker
                 .is_new_pubkey_hash_authorized(

--- a/core/lib/circuit/src/witness/tests/change_pubkey_offchain.rs
+++ b/core/lib/circuit/src/witness/tests/change_pubkey_offchain.rs
@@ -13,6 +13,7 @@ use crate::witness::{
     tests::test_utils::{generic_test_scenario, incorrect_op_test_scenario, WitnessTestAccount},
     utils::SigDataInput,
 };
+use zksync_test_account::ChangePubkeyTypeArguments;
 
 const FEE_TOKEN: u16 = 0; // ETH
 
@@ -30,7 +31,7 @@ fn test_change_pubkey_offchain_success() {
             true,
             FEE_TOKEN,
             Default::default(),
-            false,
+            ChangePubkeyTypeArguments::SignWithEthSignature,
         ),
         account_id: account.id,
     };
@@ -62,9 +63,13 @@ fn test_change_pubkey_offchain_nonzero_fee() {
     let accounts = vec![WitnessTestAccount::new(0xc1, 500u64)];
     let account = &accounts[0];
     let change_pkhash_op = ChangePubKeyOp {
-        tx: account
-            .zksync_account
-            .sign_change_pubkey_tx(None, true, FEE_TOKEN, fee, false),
+        tx: account.zksync_account.sign_change_pubkey_tx(
+            None,
+            true,
+            FEE_TOKEN,
+            fee,
+            ChangePubkeyTypeArguments::SignWithEthSignature,
+        ),
         account_id: account.id,
     };
 
@@ -107,7 +112,7 @@ fn test_incorrect_change_pubkey_account() {
             true,
             FEE_TOKEN,
             Default::default(),
-            false,
+            ChangePubkeyTypeArguments::SignWithEthSignature,
         ),
         account_id: account.id,
     };
@@ -157,7 +162,7 @@ fn test_incorrect_change_pubkey_signature() {
         true,
         FEE_TOKEN,
         Default::default(),
-        false,
+        ChangePubkeyTypeArguments::SignWithEthSignature,
     );
 
     // Change fee.

--- a/core/lib/state/benches/criterion/ops.rs
+++ b/core/lib/state/benches/criterion/ops.rs
@@ -16,6 +16,7 @@ use zksync_types::{
 };
 // Local uses
 use zksync_state::state::ZkSyncState;
+use zksync_types::tx::ChangePubKeyType;
 
 const ETH_TOKEN_ID: TokenId = 0x00;
 // The amount is not important, since we always work with 1 account.
@@ -232,17 +233,15 @@ fn apply_change_pubkey_op(b: &mut Bencher<'_>) {
         Default::default(),
         nonce,
         None,
-        None,
+        ChangePubKeyType::OnchainTransaction,
     );
 
-    change_pubkey.eth_signature = {
-        let sign_bytes = change_pubkey
-            .get_eth_signed_data()
-            .expect("Failed to construct ChangePubKey signed message.");
-        let eth_signature =
-            PackedEthSignature::sign(eth_private_key, &sign_bytes).expect("Signing failed");
-        Some(eth_signature)
-    };
+    let sign_bytes = change_pubkey
+        .get_eth_signed_data()
+        .expect("Failed to construct ChangePubKey signed message.");
+    let eth_signature =
+        PackedEthSignature::sign(eth_private_key, &sign_bytes).expect("Signing failed");
+    change_pubkey.change_pubkey_type = ChangePubKeyType::EthereumSignature { eth_signature };
 
     let change_pubkey_tx = ZkSyncTx::ChangePubKey(Box::new(change_pubkey));
 

--- a/core/lib/state/src/handler/change_pubkey.rs
+++ b/core/lib/state/src/handler/change_pubkey.rs
@@ -19,8 +19,12 @@ impl TxHandler<ChangePubKey> for ZkSyncState {
             .get_account_by_address(&tx.account)
             .ok_or_else(|| format_err!("Account does not exist"))?;
         ensure!(
-            tx.eth_signature.is_none() || tx.verify_eth_signature() == Some(account.address),
-            "ChangePubKey Ethereum signature is incorrect"
+            tx.verify_change_pubkey_type_correctness(),
+            "ChangePubKey Ethereum authentication is incorrect"
+        );
+        ensure!(
+            tx.account == account.address,
+            "ChangePubKey account address is incorrect"
         );
         ensure!(
             tx.verify_signature() == Some(tx.new_pk_hash.clone()),

--- a/core/lib/state/src/tests/operations/change_pub_key.rs
+++ b/core/lib/state/src/tests/operations/change_pub_key.rs
@@ -1,6 +1,6 @@
 use crate::tests::{AccountState::*, PlasmaTestBuilder};
 use zksync_types::account::{AccountUpdate, PubKeyHash};
-use zksync_types::tx::ChangePubKey;
+use zksync_types::tx::{ChangePubKey, ChangePubKeyType};
 
 /// Check ChangePubKey operation on new account
 #[test]
@@ -20,7 +20,7 @@ fn success() {
         token_id,
         balance.into(),
         account.nonce,
-        None,
+        ChangePubKeyType::OnchainTransaction,
         &sk,
     )
     .expect("Failed to sign ChangePubkey");
@@ -63,7 +63,7 @@ fn nonce_mismatch() {
         0,
         0u32.into(),
         account.nonce + 1,
-        None,
+        ChangePubKeyType::OnchainTransaction,
         &sk,
     )
     .expect("Failed to sign ChangePubkey");
@@ -86,7 +86,7 @@ fn invalid_account_id() {
         0,
         0u32.into(),
         account.nonce + 1,
-        None,
+        ChangePubKeyType::OnchainTransaction,
         &sk,
     )
     .expect("Failed to sign ChangePubkey");

--- a/core/lib/storage/src/tests/chain/block.rs
+++ b/core/lib/storage/src/tests/chain/block.rs
@@ -17,6 +17,7 @@ use crate::{
     prover::ProverSchema,
     QueryResult, StorageProcessor,
 };
+use zksync_test_account::ChangePubkeyTypeArguments;
 
 /// block size used for this tests
 const BLOCK_SIZE_CHUNKS: usize = 100;
@@ -606,8 +607,13 @@ async fn pending_block_workflow(mut storage: StorageProcessor<'_>) -> QueryResul
     to_zksync_account.set_account_id(Some(to_account_id));
 
     let (tx_1, executed_tx_1) = {
-        let tx =
-            from_zksync_account.sign_change_pubkey_tx(None, false, 0, Default::default(), false);
+        let tx = from_zksync_account.sign_change_pubkey_tx(
+            None,
+            false,
+            0,
+            Default::default(),
+            ChangePubkeyTypeArguments::SignWithEthSignature,
+        );
 
         let change_pubkey_op = ZkSyncOp::ChangePubKeyOffchain(Box::new(ChangePubKeyOp {
             tx: tx.clone(),

--- a/core/lib/storage/src/tests/chain/mempool.rs
+++ b/core/lib/storage/src/tests/chain/mempool.rs
@@ -3,7 +3,7 @@ use zksync_crypto::rand::{Rng, SeedableRng, XorShiftRng};
 // Workspace imports
 use zksync_types::{
     mempool::SignedTxVariant,
-    tx::{ChangePubKey, Transfer, Withdraw},
+    tx::{ChangePubKey, ChangePubKeyType, Transfer, Withdraw},
     Address, SignedZkSyncTx, ZkSyncTx,
 };
 // Local imports
@@ -61,7 +61,7 @@ fn franklin_txs() -> Vec<SignedZkSyncTx> {
         Default::default(),
         13,
         None,
-        None,
+        ChangePubKeyType::OnchainTransaction,
     );
 
     let txs = [

--- a/core/lib/storage/src/tests/chain/operations_ext/setup.rs
+++ b/core/lib/storage/src/tests/chain/operations_ext/setup.rs
@@ -5,7 +5,7 @@ use num::BigUint;
 // Workspace imports
 use zksync_crypto::franklin_crypto::bellman::pairing::ff::Field;
 use zksync_crypto::Fr;
-use zksync_test_account::ZkSyncAccount;
+use zksync_test_account::{ChangePubkeyTypeArguments, ZkSyncAccount};
 use zksync_types::block::{Block, ExecutedOperations, ExecutedPriorityOp, ExecutedTx};
 use zksync_types::operations::{ChangePubKeyOp, ZkSyncOp};
 use zksync_types::priority_ops::PriorityOp;
@@ -274,7 +274,7 @@ impl TransactionsHistoryTestSetup {
                 false,
                 0,
                 Default::default(),
-                false,
+                ChangePubkeyTypeArguments::SignWithEthSignature,
             ),
             account_id: self.from_zksync_account.get_account_id().unwrap(),
         }));

--- a/core/lib/types/src/gas_counter.rs
+++ b/core/lib/types/src/gas_counter.rs
@@ -6,7 +6,7 @@
 // Workspace deps
 use zksync_basic_types::U256;
 // Local deps
-use crate::{config::MAX_WITHDRAWALS_TO_COMPLETE_IN_A_CALL, ZkSyncOp};
+use crate::{config::MAX_WITHDRAWALS_TO_COMPLETE_IN_A_CALL, tx::ChangePubKeyType, ZkSyncOp};
 
 /// Amount of gas that we can afford to spend in one transaction.
 /// This value must be big enough to fit big blocks with expensive transactions,
@@ -42,7 +42,8 @@ impl CommitCost {
             ZkSyncOp::Noop(_) => 0,
             ZkSyncOp::Deposit(_) => Self::DEPOSIT_COST,
             ZkSyncOp::ChangePubKeyOffchain(change_pubkey) => {
-                if change_pubkey.tx.eth_signature.is_some() {
+                if matches!(change_pubkey.tx.change_pubkey_type, ChangePubKeyType::EthereumSignature{..})
+                {
                     Self::CHANGE_PUBKEY_COST_OFFCHAIN
                 } else {
                     Self::CHANGE_PUBKEY_COST_ONCHAIN
@@ -198,7 +199,7 @@ mod tests {
                 Default::default(),
                 Default::default(),
                 None,
-                None,
+                ChangePubKeyType::OnchainTransaction,
             ),
             account_id: 1,
         };
@@ -226,7 +227,7 @@ mod tests {
                 Default::default(),
                 Default::default(),
                 None,
-                None,
+                ChangePubKeyType::OnchainTransaction,
             ),
             account_id: 1,
         };
@@ -254,7 +255,7 @@ mod tests {
                 Default::default(),
                 Default::default(),
                 None,
-                None,
+                ChangePubKeyType::OnchainTransaction,
             ),
             account_id: 1,
         };

--- a/core/lib/types/src/tests/utils.rs
+++ b/core/lib/types/src/tests/utils.rs
@@ -1,4 +1,4 @@
-use crate::tx::ChangePubKey;
+use crate::tx::{ChangePubKey, ChangePubKeyType};
 use crate::*;
 use chrono::Utc;
 
@@ -63,7 +63,7 @@ pub fn create_change_pubkey_tx() -> ExecutedOperations {
             Default::default(),
             Default::default(),
             None,
-            None,
+            ChangePubKeyType::OnchainTransaction,
         ),
         account_id: 0,
     }));

--- a/core/lib/types/src/tx/mod.rs
+++ b/core/lib/types/src/tx/mod.rs
@@ -15,7 +15,7 @@ mod tests;
 #[doc(hidden)]
 pub use self::close::Close;
 pub use self::{
-    change_pubkey::ChangePubKey,
+    change_pubkey::{ChangePubKey, ChangePubKeyType},
     forced_exit::ForcedExit,
     transfer::Transfer,
     withdraw::Withdraw,

--- a/core/lib/types/src/tx/zksync_tx.rs
+++ b/core/lib/types/src/tx/zksync_tx.rs
@@ -8,6 +8,7 @@ use num::BigUint;
 use parity_crypto::digest::sha256;
 
 use crate::operations::ChangePubKeyOp;
+use crate::tx::ChangePubKeyType;
 use serde::{Deserialize, Serialize};
 use zksync_basic_types::Address;
 
@@ -210,7 +211,7 @@ impl ZkSyncTx {
             )),
             ZkSyncTx::ChangePubKey(change_pubkey) => Some((
                 TxFeeTypes::ChangePubKey {
-                    onchain_pubkey_auth: change_pubkey.eth_signature.is_none(),
+                    onchain_pubkey_auth: !matches!(change_pubkey.change_pubkey_type, ChangePubKeyType::EthereumSignature{..}),
                 },
                 TokenLike::Id(change_pubkey.fee_token),
                 change_pubkey.account,

--- a/core/tests/testkit/src/lib.rs
+++ b/core/tests/testkit/src/lib.rs
@@ -35,6 +35,7 @@ use itertools::Itertools;
 use web3::types::{TransactionReceipt, U64};
 use zksync_crypto::proof::EncodedProofPlonk;
 use zksync_crypto::rand::Rng;
+use zksync_test_account::ChangePubkeyTypeArguments;
 use zksync_types::block::Block;
 
 /// Constant for testkit
@@ -311,7 +312,7 @@ impl<T: Transport> AccountSet<T> {
             increment_nonce,
             fee_token,
             fee,
-            true,
+            ChangePubkeyTypeArguments::OnchainTransaction,
         )))
     }
 
@@ -329,7 +330,7 @@ impl<T: Transport> AccountSet<T> {
             increment_nonce,
             fee_token,
             fee,
-            false,
+            ChangePubkeyTypeArguments::SignWithEthSignature,
         )))
     }
 }

--- a/etc/js/env-config.js
+++ b/etc/js/env-config.js
@@ -23,6 +23,12 @@ export default {
         WS_API_ADDR: "wss://ropsten-api.zksync.io/jsrpc-ws",
         HTTP_RPC_API_ADDR: "https://ropsten-api.zksync.io/jsrpc",
     },
+    "https://ropsten-beta.zkscan.io": {
+        API_SERVER: "https://ropsten-beta-api.zksync.io",
+        ETH_NETWORK: "ropsten",
+        WS_API_ADDR: "wss://ropsten-beta-api.zksync.io/jsrpc-ws",
+        HTTP_RPC_API_ADDR: "https://ropsten-beta-api.zksync.io/jsrpc",
+    },
     "https://zkscan.io": {
         API_SERVER: "https://api.zksync.io",
         ETH_NETWORK: "mainnet",

--- a/sdk/zksync.js/package.json
+++ b/sdk/zksync.js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "zksync",
-    "version": "0.8.1-beta",
+    "version": "0.8.2-beta",
     "license": "MIT",
     "main": "build/index.js",
     "types": "build/index.d.ts",

--- a/sdk/zksync.js/package.json
+++ b/sdk/zksync.js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "zksync",
-    "version": "0.7.5",
+    "version": "0.8.1-beta",
     "license": "MIT",
     "main": "build/index.js",
     "types": "build/index.d.ts",

--- a/sdk/zksync.js/src/create2wallet.ts
+++ b/sdk/zksync.js/src/create2wallet.ts
@@ -1,0 +1,43 @@
+import { ethers } from "ethers";
+import { Create2WalletData } from "./types";
+import { calculateCreate2WalletAddressAndSalt } from "./utils";
+
+export class Create2WalletSigner extends ethers.Signer {
+    public readonly address: string;
+    // salt for create2 function call
+    public readonly salt: string;
+    constructor(
+        public zkSyncPubkeyHash: string,
+        public create2WalletData: Create2WalletData,
+        provider?: ethers.providers.Provider
+    ) {
+        super();
+        Object.defineProperty(this, "provider", {
+            enumerable: true,
+            value: provider,
+            writable: false
+        });
+        const create2Info = calculateCreate2WalletAddressAndSalt(zkSyncPubkeyHash, create2WalletData);
+        this.address = create2Info.address;
+        this.salt = create2Info.salt;
+    }
+
+    async getAddress() {
+        return this.address;
+    }
+
+    /**
+     * This signer can't sign messages but we return zeroed signature bytes to comply with zksync API for now.
+     */
+    async signMessage(_message) {
+        return "0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+    }
+
+    async signTransaction(_message): Promise<string> {
+        throw new Error("Create2Wallet signer can't sign transactions");
+    }
+
+    connect(provider: ethers.providers.Provider): ethers.Signer {
+        return new Create2WalletSigner(this.zkSyncPubkeyHash, this.create2WalletData, provider);
+    }
+}

--- a/sdk/zksync.js/src/index.ts
+++ b/sdk/zksync.js/src/index.ts
@@ -7,6 +7,7 @@ import * as wallet from "./wallet";
 import * as types from "./types";
 import * as utils from "./utils";
 import * as crypto from "./crypto";
+import * as create2wallet from "./create2wallet";
 
 export {
     Wallet,
@@ -19,5 +20,6 @@ export {
     types,
     utils,
     crypto,
-    wallet
+    wallet,
+    create2wallet
 };

--- a/sdk/zksync.js/src/provider.ts
+++ b/sdk/zksync.js/src/provider.ts
@@ -11,7 +11,7 @@ import {
     TokenAddress,
     TxEthSignature,
     Fee,
-    ChangePubKeyFee,
+    ChangePubKeyFee
 } from "./types";
 import { isTokenETH, sleep, SYNC_GOV_CONTRACT_INTERFACE, SYNC_MAIN_CONTRACT_INTERFACE, TokenSet } from "./utils";
 
@@ -121,16 +121,16 @@ export class Provider {
 
     async notifyPriorityOp(serialId: number, action: "COMMIT" | "VERIFY"): Promise<PriorityOperationReceipt> {
         if (this.transport.subscriptionsSupported()) {
-            return await new Promise((resolve) => {
+            return await new Promise(resolve => {
                 const startTime = new Date().getTime();
                 const subscribe = this.transport.subscribe(
                     "ethop_subscribe",
                     [serialId, action],
                     "ethop_unsubscribe",
-                    (resp) => {
+                    resp => {
                         subscribe
-                            .then((sub) => sub.unsubscribe())
-                            .catch((err) => console.log(`WebSocket connection closed with reason: ${err}`));
+                            .then(sub => sub.unsubscribe())
+                            .catch(err => console.log(`WebSocket connection closed with reason: ${err}`));
                         resolve(resp);
                     }
                 );
@@ -153,11 +153,11 @@ export class Provider {
 
     async notifyTransaction(hash: string, action: "COMMIT" | "VERIFY"): Promise<TransactionReceipt> {
         if (this.transport.subscriptionsSupported()) {
-            return await new Promise((resolve) => {
-                const subscribe = this.transport.subscribe("tx_subscribe", [hash, action], "tx_unsubscribe", (resp) => {
+            return await new Promise(resolve => {
+                const subscribe = this.transport.subscribe("tx_subscribe", [hash, action], "tx_unsubscribe", resp => {
                     subscribe
-                        .then((sub) => sub.unsubscribe())
-                        .catch((err) => console.log(`WebSocket connection closed with reason: ${err}`));
+                        .then(sub => sub.unsubscribe())
+                        .catch(err => console.log(`WebSocket connection closed with reason: ${err}`));
                     resolve(resp);
                 });
             });
@@ -189,7 +189,7 @@ export class Provider {
             gasPriceWei: BigNumber.from(transactionFee.gasPriceWei),
             gasFee: BigNumber.from(transactionFee.gasFee),
             zkpFee: BigNumber.from(transactionFee.zkpFee),
-            totalFee: BigNumber.from(transactionFee.totalFee),
+            totalFee: BigNumber.from(transactionFee.totalFee)
         };
     }
 

--- a/sdk/zksync.js/src/provider.ts
+++ b/sdk/zksync.js/src/provider.ts
@@ -16,7 +16,7 @@ import {
 import { isTokenETH, sleep, SYNC_GOV_CONTRACT_INTERFACE, SYNC_MAIN_CONTRACT_INTERFACE, TokenSet } from "./utils";
 
 export async function getDefaultProvider(
-    network: "localhost" | "rinkeby" | "ropsten" | "mainnet",
+    network: "localhost" | "rinkeby" | "ropsten" | "mainnet" | "ropsten-beta",
     transport: "WS" | "HTTP" = "WS"
 ): Promise<Provider> {
     if (network === "localhost") {
@@ -30,6 +30,12 @@ export async function getDefaultProvider(
             return await Provider.newWebsocketProvider("wss://ropsten-api.zksync.io/jsrpc-ws");
         } else if (transport === "HTTP") {
             return await Provider.newHttpProvider("https://ropsten-api.zksync.io/jsrpc");
+        }
+    } else if (network === "ropsten-beta") {
+        if (transport === "WS") {
+            return await Provider.newWebsocketProvider("wss://ropsten-beta-api.zksync.io/jsrpc-ws");
+        } else if (transport === "HTTP") {
+            return await Provider.newHttpProvider("https://ropsten-beta-api.zksync.io/jsrpc");
         }
     } else if (network === "rinkeby") {
         if (transport === "WS") {

--- a/sdk/zksync.js/src/signer.ts
+++ b/sdk/zksync.js/src/signer.ts
@@ -10,7 +10,7 @@ import {
     serializeAmountPacked,
     serializeFeePacked,
     serializeNonce,
-    serializeAmountFull,
+    serializeAmountFull
 } from "./utils";
 import { Address, EthSignerType, PubKeyHash, Transfer, Withdraw, ForcedExit, ChangePubKey } from "./types";
 
@@ -55,7 +55,7 @@ export class Signer {
             amount: BigNumber.from(transfer.amount).toString(),
             fee: BigNumber.from(transfer.fee).toString(),
             nonce: transfer.nonce,
-            signature,
+            signature
         };
     }
 
@@ -84,7 +84,7 @@ export class Signer {
             tokenIdBytes,
             amountBytes,
             feeBytes,
-            nonceBytes,
+            nonceBytes
         ]);
         const signature = signTransactionBytes(this.privateKey, msgBytes);
         return {
@@ -96,7 +96,7 @@ export class Signer {
             amount: BigNumber.from(withdraw.amount).toString(),
             fee: BigNumber.from(withdraw.fee).toString(),
             nonce: withdraw.nonce,
-            signature,
+            signature
         };
     }
 
@@ -119,7 +119,7 @@ export class Signer {
             targetBytes,
             tokenIdBytes,
             feeBytes,
-            nonceBytes,
+            nonceBytes
         ]);
         const signature = signTransactionBytes(this.privateKey, msgBytes);
         return {
@@ -129,7 +129,7 @@ export class Signer {
             token: forcedExit.tokenId,
             fee: BigNumber.from(forcedExit.fee).toString(),
             nonce: forcedExit.nonce,
-            signature,
+            signature
         };
     }
 
@@ -155,7 +155,7 @@ export class Signer {
             pubKeyHashBytes,
             tokenIdBytes,
             feeBytes,
-            nonceBytes,
+            nonceBytes
         ]);
         const signature = signTransactionBytes(this.privateKey, msgBytes);
         return {
@@ -167,7 +167,7 @@ export class Signer {
             fee: BigNumber.from(changePubKey.fee).toString(),
             nonce: changePubKey.nonce,
             signature,
-            ethSignature: null,
+            changePubkeyType: null
         };
     }
 

--- a/sdk/zksync.js/src/transport.ts
+++ b/sdk/zksync.js/src/transport.ts
@@ -42,10 +42,10 @@ export class HTTPTransport extends AbstractJSONRPCTransport {
             id: 1,
             jsonrpc: "2.0",
             method,
-            params,
+            params
         };
 
-        const response = await Axios.post(this.address, request).then((resp) => {
+        const response = await Axios.post(this.address, request).then(resp => {
             return resp.data;
         });
 
@@ -71,17 +71,17 @@ export class WSTransport extends AbstractJSONRPCTransport {
     private constructor(public address: string) {
         super();
         this.ws = new WebSocketAsPromised(address, {
-            createWebSocket: (url) => new W3CWebSocket(url),
-            packMessage: (data) => JSON.stringify(data),
-            unpackMessage: (data) => JSON.parse(data as string),
+            createWebSocket: url => new W3CWebSocket(url),
+            packMessage: data => JSON.stringify(data),
+            unpackMessage: data => JSON.parse(data as string),
             attachRequestId: (data, requestId) => Object.assign({ id: requestId }, data), // attach requestId to message as `id` field
-            extractRequestId: (data) => data && data.id,
+            extractRequestId: data => data && data.id
         });
 
         this.subscriptionCallback = new Map();
 
         // Call all subscription callbacks
-        this.ws.onUnpackedMessage.addListener((data) => {
+        this.ws.onUnpackedMessage.addListener(data => {
             if (data.params && data.params.subscription) {
                 const params = data.params;
                 if (this.subscriptionCallback.has(params.subscription)) {
@@ -116,7 +116,7 @@ export class WSTransport extends AbstractJSONRPCTransport {
             const unsubRep = await this.ws.sendRequest({
                 jsonrpc: "2.0",
                 method: unsubMethod,
-                params: [subId],
+                params: [subId]
             });
             if (unsubRep.error) {
                 throw new JRPCError(`Unsubscribe failed: ${subId}, ${JSON.stringify(unsubRep.error)}`, unsubRep.error);
@@ -135,7 +135,7 @@ export class WSTransport extends AbstractJSONRPCTransport {
         const request = {
             jsonrpc: "2.0",
             method,
-            params,
+            params
         };
 
         const response = await this.ws.sendRequest(request);

--- a/sdk/zksync.js/src/types.ts
+++ b/sdk/zksync.js/src/types.ts
@@ -1,4 +1,4 @@
-import { BigNumber, BigNumberish } from "ethers";
+import { BigNumber, BigNumberish, utils } from "ethers";
 
 // 0x-prefixed, hex encoded, ethereum account address
 export type Address = string;
@@ -98,6 +98,24 @@ export interface ForcedExit {
     signature: Signature;
 }
 
+export type ChangePubkeyTypes = "OnchainTransaction" | "EthereumSignature" | "Create2Contract";
+
+export interface ChangePubkeyEthereumSignature {
+    type: "EthereumSignature";
+    ethSignature: string;
+}
+
+export interface ChangePubkeyOnchainTransaction {
+    type: "OnchainTransaction";
+}
+
+export interface ChangePubkeyCreate2Contract {
+    type: "Create2Contract";
+    creatorAddress: string;
+    saltArg: string;
+    codeHash: string;
+}
+
 export interface ChangePubKey {
     type: "ChangePubKey";
     accountId: number;
@@ -107,7 +125,7 @@ export interface ChangePubKey {
     fee: BigNumberish;
     nonce: number;
     signature: Signature;
-    ethSignature: string;
+    changePubkeyType: ChangePubkeyEthereumSignature | ChangePubkeyOnchainTransaction | ChangePubkeyCreate2Contract;
 }
 
 export interface CloseAccount {
@@ -184,4 +202,11 @@ export interface Fee {
 export interface BatchFee {
     // Total fee amount (in wei)
     totalFee: BigNumber;
+}
+
+export interface Create2WalletData {
+    creatorAddress: string;
+    // 32 bytes of additional data to code in the resulting wallet
+    saltArg: string;
+    codeHash: string;
 }


### PR DESCRIPTION
@@ -547,10 +547,17 @@ contract ZkSync is UpgradeableMaster, Storage, Config, Events, ReentrancyGuard {
                    Operations.ChangePubKey memory op = Operations.readChangePubKeyPubdata(_publicData, pubdataOffset + 1);

                    if (_ethWitnessSizes[processedOperationsRequiringEthWitness] != 0) {
                        bytes memory currentEthWitness = Bytes.slice(_ethWitness, ethWitnessOffset, _ethWitnessSizes[processedOperationsRequiringEthWitness]);

                        bool valid = verifyChangePubkeySignature(currentEthWitness, op.pubKeyHash, op.nonce, op.owner, op.accountId);
                        require(valid, "fpp15"); // failed to verify change pubkey hash signature
                        bytes memory currentEthWitnessWithoutType = Bytes.slice(_ethWitness, ethWitnessOffset + 1, _ethWitnessSizes[processedOperationsRequiringEthWitness] - 1);

                        if (_ethWitness[ethWitnessOffset] == 0x01) {
                            bool valid = verifyChangePubkeySignature(currentEthWitnessWithoutType, op.pubKeyHash, op.nonce, op.owner, op.accountId);
                            require(valid, "chp1"); // failed to verify change pubkey hash signature
                        } else if (_ethWitness[ethWitnessOffset] == 0x02) {
                            bool valid = verifyChangePubkeyCreate2(currentEthWitnessWithoutType, op.pubKeyHash, op.nonce, op.owner);
                            require(valid, "chp2"); // failed to verify CREATE2 signature
                        } else {
                            revert("chp00"); // unknown verify signature type
                        }
                    } else {
                        bool valid = authFacts[op.owner][op.nonce] == keccak256(abi.encodePacked(op.pubKeyHash));
                        require(valid, "fpp16"); // new pub key hash is not authenticated properly
@@ -593,6 +600,21 @@ contract ZkSync is UpgradeableMaster, Storage, Config, Events, ReentrancyGuard {
        return recoveredAddress == _ethAddress;
    }

    /// @notice Checks that signature is valid for pubkey change message

    function verifyChangePubkeyCreate2(bytes memory _args, bytes20 _newPkHash, uint32 _nonce, address _ethAddress) internal pure returns (bool) {
        uint offset  = 0;
        address creatorAddress;
        bytes32 saltArg;
        bytes32 codeHash;
        (offset, creatorAddress) = Bytes.readAddress(_args, offset);
        (offset, saltArg) = Bytes.readBytes32(_args, offset);
        (offset, codeHash) = Bytes.readBytes32(_args, offset);
        bytes32 salt = keccak256(abi.encodePacked(_newPkHash,saltArg));
        address recoveredAddress = address(uint160(uint256(keccak256(abi.encodePacked(bytes1(0xff), creatorAddress, salt, codeHash)))));
        return recoveredAddress == _ethAddress && _nonce == 0;
    }

    /// @notice Creates block commitment from its data
    /// @param _blockNumber Block number
    /// @param _feeAccount Account to collect fees