### PR TITLE
Fix typos in architecture.md and contract.md

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,15 +9,15 @@ zkSync repository consists of several applications:
 - zkSync smart contract: a Solidity smart contract deployed on the Ethereum blockchain, which manages users' balances
   and verifies the correctness of operations performed within zkSync network.
 - Prover application: a worker application that creates a proof for an executed block. Prover applications poll Server
-  application for available jobs, and once there is a new block, server provides a witness (input data to generate a
-  proof), and prover starts working. Once proof is generated, it is reported to the Server application, and Server
+  application for available jobs, and once there is a new block, the server provides a witness (input data to generate 
+  proof), and the prover starts working. Once proof is generated, it is reported to the Server application, and the Server
   publishes the proof to the smart contract. Prover application is considered an on-demand worker, thus it is OK to have
-  many provers (if server load is high) or no provers at all (if there are no incoming transactions). Generating a proof
-  is a very resource consuming work, thus machines that run a prover application must have a modern CPU and a lot of
+  many provers (if the server load is high) or no provers at all (if there are no incoming transactions). Generating a proof
+  is very resource-consuming work, thus machines that run a prover application must have a modern CPU and a lot of
   RAM.
-- Server application: a node running the zkSync network. It is capable of following things:
+- Server application: a node running the zkSync network. It is capable of the following things:
 
-  - Monitoring the smart contract for the onchain operations (such as deposits).
+  - Monitoring the smart contract for the on-chain operations (such as deposits).
   - Accepting transactions.
   - Generating zkSync chain blocks.
   - Requesting proofs for executed blocks.
@@ -26,14 +26,14 @@ zkSync repository consists of several applications:
   Server application exists in two available forms:
 
   - Monolithic application, which provides all the required functionality from one binary. This form is convenient for
-    the development needs. Corresponding crate is `core/bin/server`.
+    the development needs. The corresponding crate is `core/bin/server`.
   - Microservices applications, which are capable of working independently from each other:
-    - `Core` service (`core/bin/zksync_core`) maintains transactions memory pool and commits new blocks.
+    - `Core` service (`core/bin/zksync_core`) maintains the transactions memory pool and commits new blocks.
     - `API` service (`core/bin/zksync_api`) provides a server "front-end": REST API & JSON RPC HTTP/WS implementations.
     - `Ethereum Sender` service (`core/bin/zksync_eth_sender`) finalizes the blocks by sending corresponding Ethereum
       transactions to the L1 smart contract.
     - `Witness Generator` service (`core/bin/zksync_witness_generator`) creates input data required for provers to prove
-      blocks, and implements a private API server for provers to interact with.
+      blocks and implements a private API server for provers to interact with.
 
 Thus, in order to get a local zkSync setup running, the following has to be done:
 
@@ -43,10 +43,10 @@ Thus, in order to get a local zkSync setup running, the following has to be done
 
 ## Low-Level Overview
 
-This section provides an overview on folders / sub-projects that exist in this repository.
+This section provides an overview of folders / sub-projects that exist in this repository.
 
-- `/bin`: Infrastructure scripts which help to work with zkSync applications.
-- `/contracts`: Everything related to zkSync smart-contract.
+- `/bin`: Infrastructure scripts that help to work with zkSync applications.
+- `/contracts`: Everything related to zkSync smart contract.
   - `/contracts`: Smart contracts code
   - `/scripts` && `/src.ts`: TypeScript scripts for smart contracts management.
 - `/core`: Code of the sub-projects that implement zkSync network.
@@ -54,15 +54,15 @@ This section provides an overview on folders / sub-projects that exist in this r
     - `/server`: zkSync server application.
     - `/prover`: zkSync prover application.
     - `/data_restore`: Utility to restore a state of the zkSync network from a smart contract.
-    - `/key_generator`: Utility to generate verification keys for network.
+    - `/key_generator`: Utility to generate verification keys for the network.
     - `/parse_pub_data`: Utility to parse zkSync operation pubdata.
     - `/zksync_core`: zkSync server Core microservice.
     - `/zksync_api`: zkSync server API microservice.
     - `/zksync_eth_sender`: zkSync server Ethereum sender microservice.
     - `/zksync_witness_generator`: zkSync server Witness Generator & Prover Server microservice.
   - `/lib`: Dependencies of the binaries above.
-    - `/basic_types`: Crate with declaration of the essential zkSync primitives, such as `address`.
-    - `/circuit`: Cryptographic environment enforsing the correctness of executed transactions in the zkSync network.
+    - `/basic_types`: Crate with the declaration of the essential zkSync primitives, such as `address`.
+    - `/circuit`: Cryptographic environment enforcing the correctness of executed transactions in the zkSync network.
     - `/config`: Utilities to load configuration options of zkSync applications.
     - `/contracts`: Loaders for zkSync contracts interfaces and ABI.
     - `/crypto`: Cryptographical primitives using among zkSync crates.
@@ -71,18 +71,18 @@ This section provides an overview on folders / sub-projects that exist in this r
     - `/prover_utils`: Utilities related to the proof generation.
     - `/state`: A fast pre-circuit executor for zkSync transactions used on the Server level to generate blocks.
     - `/storage`: An encapsulated database interface.
-    - `/types`: zkSync network operations, transactions and common types.
+    - `/types`: zkSync network operations, transactions, and common types.
     - `/utils`: Miscellaneous helpers for zkSync crates.
-    - `/vlog`: An utility library for verbose logging.
+    - `/vlog`: A utility library for verbose logging.
   - `/tests`: Testing infrastructure for zkSync network.
     - `/loadnext`: An application for highload testing of zkSync server.
-    - `/test_account`: A representation of zkSync account which can be used for tests.
+    - `/test_account`: A representation of zkSync account that can be used for tests.
     - `/testkit`: A relatively low-level testing library and test suite for zkSync.
     - `/ts-tests`: Integration tests set implemented in TypeScript. Requires a running Server and Prover applications to
       operate.
 - `/docker`: Dockerfiles used for development of zkSync and for packaging zkSync for a production environment.
-- `/etc`: Configration files.
-  - `/env`: `.env` files that contain environment variables for different configuration of zkSync Server / Prover.
+- `/etc`: Configuration files.
+  - `/env`: `.env` files that contain environment variables for different configurations of zkSync Server / Prover.
   - `/js`: Configuration files for JavaScript applications (such as Explorer).
   - `/tokens`: Configuration of supported Ethereum ERC-20 tokens.
 - `/infrastructure`: Application that aren't naturally a part of zkSync core, but are related to it.

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -5,25 +5,25 @@
 ## Deployment
 
 The contract must be deployed specifying the initial ("genesis") state root hash, appointing the **network governor**
-(see the "Governance" section), and linking the exit queue (see the "Cenosorship resistance" section).
+(see the "Governance" section), and linking the exit queue (see the "Censorship resistance" section).
 
 ## Governance
 
-Governance of the network will be excerised from a separate contract registered in the ZKSync contract as
+Governance of the network will be exercised from a separate contract registered in the ZKSync contract as
 `networkGovernor`. It has the power to:
 
 - Change the set of validators.
 - Add new tokens (tokens can not be removed after being added).
 - Initiate migration to a new contract (see the "Migration" section).
 
-## Cenosorship resistance
+## Censorship resistance
 
-To enforece censorship-resistance and enable guaranteed retrievability of the funds, ZKSync employs the mechanisms of
+To enforce censorship-resistance and enable guaranteed retrievability of the funds, ZKSync employs the mechanisms of
 **Priority queue** (soft enforcement) and **Exodus mode** (hard enforcement).
 
 ## Deposits
 
-To make deposit, a user can:
+To make a deposit, a user can:
 
 - Either send ETH to smart contract (will be handled by the default function),
 - or call `depositERC20()` function to perform transferFrom for a registered ERC20 token. Note: the user must have
@@ -32,17 +32,17 @@ To make deposit, a user can:
 
 This deposit creates **deposit priority request** that is placed in corresponding priority requests mapping and also
 emits **NewPriorityRequest(opType, pubData, expirationBlock)** event to notify validators that they must include this
-request to upcoming blocks. Complete **PriorityQueue** logic that handles **priority requests** is described in
+request in upcoming blocks. Complete **PriorityQueue** logic that handles **priority requests** is described in
 **Priority Requests** section.
 
-When a validator commits a block which contains **circuit operations** `deposit`, **deposit onchain operation** for this
-deposit is created to verify compliance with priority queue requests. If it succeeds than their count will be added to
+When a validator commits a block that contains **circuit operations** `deposit`, **deposit onchain operation** for this
+deposit is created to verify compliance with priority queue requests. If it succeeds then their count will be added to
 **priority requests** count for this block. If the block is not verified, **deposit onchain operations** and **deposit
 priority request** are simply discarded.
 
 If the block is reverted **deposit onchain operations** are simply discarded.
 
-If ZKSync contract has entered Exodus mode and the block is unverified, the funds held by this blocks' **Deposit
+If ZKSync contract has entered Exodus mode and the block is unverified, the funds held by this block's **Deposit
 priority requests** are accrued to the owners' **root-chain balances** to make them possible to withdraw. This
 **withdraw onchain operations** and **full exit priority requests** are simply discarded.
 
@@ -52,9 +52,9 @@ priority requests** are accrued to the owners' **root-chain balances** to make t
 
 It is a standard withdrawal operation. When a block with `partial_exit` **circuit operation** is committed, **withdraw
 onchain operation** for this withdrawal is created. If the block is verified, funds from the **withdrawal onchain
-operation** are acrued to the users' **root-chain balances**.
+operation** are accrued to the users' **root-chain balances**.
 
-If the block is reverted, this **withdraw onchain operations** are simply discarded.
+If the block is reverted, these **withdraw onchain operations** are simply discarded.
 
 A user can withdraw funds from the **root-chain balance** at any time by calling a `withdrawETH()` or `withdrawERC20()`
 function.
@@ -70,7 +70,7 @@ priority request** that is placed in corresponding priority requests mapping and
 this request to upcoming blocks. Complete **PriorityQueue** logic that handles **priority requests** is described in
 **Priority Requests** section.
 
-When a validator commits a block which contains a **circuit operation** `full_exit`, the corresponding **withdraw
+When a validator commits a block that contains a **circuit operation** `full_exit`, the corresponding **withdraw
 onchain operation** for this withdrawal is created to verify compliance with priority queue requests. If it succeeds
 than their count will be added to **priority requests** count for this block. If the block is verified, funds from the
 **withdrawal onchain operation** are accrued to the users' **root-chain balances** and **withdraw onchain operations**
@@ -81,7 +81,7 @@ If the block is reverted, this **withdraw onchain operations** are simply discar
 If ZKSync contract has entered Exodus mode and the block is unverified, this **withdraw onchain operations** and **full
 exit priority requests** are simply discarded.
 
-## Block committment
+## Block commitment
 
 Only a sender from the validator set can commit a block.
 
@@ -100,19 +100,19 @@ reverted and the funds held by **onchain operations** and **priority requests** 
 
 ## Priority queue
 
-This queue will be implemented in separate contract to ensure that priority operations like `deposit` and `full_exit`
+This queue will be implemented in a separate contract to ensure that priority operations like `deposit` and `full_exit`
 will be processed in a timely manner and will be included in one of ZKSync's blocks (a situation that leads to the need
-to reverse blocks will not happen), and also, in the case of `full_exit` transactions, the user can always withdraw
+to reverse blocks will not happen), also, in the case of `full_exit` transactions, the user can always withdraw
 funds (censorship-resistance). Its' functionality is divided into 2 parts: **Requests Queue** and **Exodus Mode**.
 
-**NewPriorityRequest** event is emitted when a user send according transaction to ZKSync contract. Also some info about
+**NewPriorityRequest** event is emitted when a user sends according to transaction to ZKSync contract. Also some info about
 it will be stored in the mapping (operation type and expiration block) strictly in the order of arrival.
 **NewPriorityRequest** event structure:
 
 - `serialId` - serial id of this priority request
 - `opType` - operation type
 - `pubData` - request data
-- `expirationBlock` - the number of Ethereum block when request becomes expired `expirationBlock` is calculated as
+- `expirationBlock` - the number of Ethereum blocks when request becomes expired `expirationBlock` is calculated as
   follows: `expirationBlock = block.number + 250` - about 1 hour for the transaction to expire, `block.number` - current
   Ethereum block number.
 
@@ -120,13 +120,13 @@ When corresponding transactions are found in the commited block, their count mus
 this count of the satisfied **priority requests** is removed from mapping.
 
 If the block is reverted via Exodus Mode, the funds held by **Deposit priority requests** from this block are accrued to
-the owners' **root-chain balances** to make them possible to withdraw. And this **Deposit priority requests** will be
+the owners' **root-chain balances** to make it possible to withdraw. And this **Deposit priority requests** will be
 removed from mapping.
 
 ### Fees for Priority Requests
 
-In order to send priority request, the _user_ MUST pay some extra fee. That fee will be subtracted from the amount of
-Ether that the user sent to Deposit or Full Exit funcitons. That fee will be the payment for the _validator’s_ work to
+In order to send a priority request, the _user_ MUST pay some extra fee. That fee will be subtracted from the amount of
+Ether that the user sent to Deposit or Full Exit functions. That fee will be the payment for the _validator’s_ work to
 include these transactions in the block. One transaction fee is calculated as follows:
 `fee = FEE_COEFF * (BASE_GAS + gasleft) * gasprice`, where
 
@@ -145,9 +145,9 @@ by the increasing probability of entering the **Exodus Mode** (described below).
 
 ### Exodus mode
 
-If the **Requests Queue** is being processed too slow, it will trigger the **Exodus mode** in **ZKSync** contract. This
+If the **Requests Queue** is being processed too slowly, it will trigger the **Exodus mode** in **ZKSync** contract. This
 moment is determined by the first (oldest) **priority request** with oldest `expirationBlock` value . If
-`current ethereum block number >= oldest expiration block number` the **Exodus Mode** will be entered.
+`current Ethereum block number >= oldest expiration block number` the **Exodus Mode** will be entered.
 
 In the **Exodus mode**, the contract freezes all block processing, and all users must exit. All existing block
 commitments will be reverted.
@@ -167,7 +167,7 @@ shall be easy and cheap, but MUST require a separate opt-in or allow the user to
 The update mechanism shall follow this workflow:
 
 - The **network governor** can schedule an update, specifying a target contract and an ETH block deadline.
-- A scheduled update can not be cancelled (to proceed with migration even if exodus mode is activated while waiting for
+- A scheduled update can not be canceled (to proceed with migration even if exodus mode is activated while waiting for
   the migration; otherwise we would need to recover funds scheduled for migration with a separate procedure).
 - Users can opt-in via a separate ZKSync operation: move specific token balance into a subtree on a special migration
   account. This subtree must also maintain and update counters for total balances per token.


### PR DESCRIPTION
Small typos were fixed in the architecture.md