### PR TITLE
Replace broken link to documentinon by working one

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This architecture provides the following guarantees:
 
 In other words, ZK Rollup strictly inherits the security guarantees of the underlying L1.
 
-To learn how to use zkSync, please refer to the [zkSync SDK documentation](https://zksync.io/api/sdk/).
+To learn how to use zkSync, please refer to the [zkSync SDK documentation](https://docs.zksync.io/build/).
 
 ## Development Documentation
 


### PR DESCRIPTION
The previous link was redirecting to a 404 page. This PR updates the link with a correct one.