### PR TITLE
Fix: typo

### DIFF
--- a/sdk/zksync-rs/README.md
+++ b/sdk/zksync-rs/README.md
@@ -11,4 +11,4 @@ Full reference on how to use the library can be found [here](https://docs.zksync
 
 ## Changelog
 
-The changelog of the zksync_rs is avaliable [here](/changelog/rust-sdk.md).
+The changelog of the zksync_rs is available [here](/changelog/rust-sdk.md).


### PR DESCRIPTION
A small typo was fixed. The original text "avaliable" was changed to "available".