### PR TITLE
Gas Optimization Update for Proxy.sol

### DIFF
--- a/contracts/contracts/Proxy.sol
+++ b/contracts/contracts/Proxy.sol
@@ -70,30 +70,22 @@ contract Proxy is Upgradeable, UpgradeableMaster, Ownable {
     /// @dev Fallback function allowing to perform a delegatecall to the given implementation
     /// This function will return whatever the implementation call returns
     function _fallback() internal {
-        address _target = getTarget();
-        assembly {
-            // The pointer to the free memory slot
-            let ptr := mload(0x40)
-            // Copy function signature and arguments from calldata at zero position into memory at pointer position
-            calldatacopy(ptr, 0x0, calldatasize())
-            // Delegatecall method of the implementation contract, returns 0 on error
-            let result := delegatecall(gas(), _target, ptr, calldatasize(), 0x0, 0)
-            // Get the size of the last return data
-            let size := returndatasize()
-            // Copy the size length of bytes from return data at zero position to pointer position
-            returndatacopy(ptr, 0x0, size)
-            // Depending on result value
-            switch result
-            case 0 {
-                // End execution and revert state changes
-                revert(ptr, size)
-            }
-            default {
-                // Return data with length of size at pointers position
-                return(ptr, size)
-            }
+    address _target = getTarget();
+    assembly {
+        // Delegatecall method of the implementation contract, returns 0 on error
+        let result := delegatecall(gas(), _target, 0, calldatasize(), 0, 0)
+        // Depending on result value
+        switch result
+        case 0 {
+            // End execution and revert state changes
+            revert(0, 0)
+        }
+        default {
+            // Return the result
+            return(0, 0)
         }
     }
+}
 
     /// @notice Will run when no functions matches call data
     fallback() external payable {


### PR DESCRIPTION
In the original _fallback() function, the entire calldata is copied to memory, then passed to the delegatecall. I believe this involves unnecessary gas costs for memory operations. Possibly eliminate the memory copying step and directly pass the calldata pointer to the delegatecall. This should reduce gas costs by avoiding unnecessary memory operations.