### PR TITLE
Fixed spelling errors and clarified documentation in docs/architecture.md

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -62,10 +62,10 @@ This section provides an overview on folders / sub-projects that exist in this r
     - `/zksync_witness_generator`: zkSync server Witness Generator & Prover Server microservice.
   - `/lib`: Dependencies of the binaries above.
     - `/basic_types`: Crate with declaration of the essential zkSync primitives, such as `address`.
-    - `/circuit`: Cryptographic environment enforsing the correctness of executed transactions in the zkSync network.
+    - `/circuit`: Cryptographic environment enforcing the correctness of executed transactions in the zkSync network.
     - `/config`: Utilities to load configuration options of zkSync applications.
     - `/contracts`: Loaders for zkSync contracts interfaces and ABI.
-    - `/crypto`: Cryptographical primitives using among zkSync crates.
+    - `/crypto`: Cryptographic primitives used among zkSync crates.
     - `/eth_client`: Module providing an interface to interact with an Ethereum node.
     - `/prometheus_exporter`: Prometheus data exporter.
     - `/prover_utils`: Utilities related to the proof generation.
@@ -73,7 +73,7 @@ This section provides an overview on folders / sub-projects that exist in this r
     - `/storage`: An encapsulated database interface.
     - `/types`: zkSync network operations, transactions and common types.
     - `/utils`: Miscellaneous helpers for zkSync crates.
-    - `/vlog`: An utility library for verbose logging.
+    - `/vlog`: A utility library for verbose logging.
   - `/tests`: Testing infrastructure for zkSync network.
     - `/loadnext`: An application for highload testing of zkSync server.
     - `/test_account`: A representation of zkSync account which can be used for tests.
@@ -81,11 +81,11 @@ This section provides an overview on folders / sub-projects that exist in this r
     - `/ts-tests`: Integration tests set implemented in TypeScript. Requires a running Server and Prover applications to
       operate.
 - `/docker`: Dockerfiles used for development of zkSync and for packaging zkSync for a production environment.
-- `/etc`: Configration files.
-  - `/env`: `.env` files that contain environment variables for different configuration of zkSync Server / Prover.
+- `/etc`: Configuration files.
+  - `/env`: `.env` files that contain environment variables for different configurations of the zkSync Server/Prover.
   - `/js`: Configuration files for JavaScript applications (such as Explorer).
   - `/tokens`: Configuration of supported Ethereum ERC-20 tokens.
-- `/infrastructure`: Application that aren't naturally a part of zkSync core, but are related to it.
+- `/infrastructure`: Applications that aren't naturally a part of the zkSync core but are related to it.
 - `/keys`: Verification keys for `circuit` module.
 - `/sdk`: Implementation of client libraries for zkSync network in different programming languages.
   - `/zksync-crypto`: zkSync network cryptographic primitives, which can be compiled to WASM.


### PR DESCRIPTION
In this commit, we made several corrections and improvements to the architecture.md file to enhance its readability and accuracy. The changes include:

1. Corrected "Configration files." to "Configuration files." for accuracy.
2. Rephrased "Cryptographical primitives using among zkSync crates." to "Cryptographic primitives used among zkSync crates." for clarity.
3. Corrected "Cryptographic environment enforsing the correctness of executed transactions in the zkSync network." to "Cryptographic environment enforcing the correctness of executed transactions in the zkSync network." to fix spelling errors.
4. Changed "An utility library for verbose logging." to "A utility library for verbose logging." to correct article usage.
5. Improved "env: .env files that contain environment variables for different configuration of zkSync Server / Prover." to "env: .env files that contain environment variables for different configurations of the zkSync Server/Prover." for clarity.
6. Corrected "Application that aren't naturally a part of zkSync core, but are related to it." to "Applications that aren't naturally a part of the zkSync core but are related to it." for grammatical accuracy.

These corrections and clarifications are aimed at ensuring the document is both precise and easy to understand, thereby improving the overall quality of the documentation.