### PR TITLE
chore: fix typos

### DIFF
--- a/changelog/js-sdk.md
+++ b/changelog/js-sdk.md
@@ -34,7 +34,7 @@ All notable changes to `zksync.js` will be documented in this file.
 - `SyncProvider` interface: common interface for API v0.2 `RestProvider` and JSON RPC `Provider`.
 - Types for REST API v0.2.
 
-- `RestProvider` class, that is used for queriing REST API v0.2.
+- `RestProvider` class, that is used for querying REST API v0.2.
 - `SyncProvider` interface: common interface for API v0.2 `RestProvider` and JSON RPC `Provider`.
 - Types for REST API v0.2.
 

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -11,4 +11,4 @@ zkSync strictly inherits the security assumptions of L1 [here](https://zksync.io
 
 ## Changelog
 
-The changelog of the contracts is avaliable [here](/changelog/contracts.md).
+The changelog of the contracts is available [here](/changelog/contracts.md).

--- a/core/README.md
+++ b/core/README.md
@@ -11,4 +11,4 @@ You can read description of the API provided [here](https://zksync.io/api/).
 
 ## Changelog
 
-The changelog of the contracts is avaliable [here](/changelog/core.md).
+The changelog of the contracts is available [here](/changelog/core.md).

--- a/core/bin/zksync_api/src/api_server/forced_exit_checker.rs
+++ b/core/bin/zksync_api/src/api_server/forced_exit_checker.rs
@@ -24,7 +24,7 @@ pub trait ForcedExitAccountAgeChecker {
 
 #[derive(Clone)]
 pub struct ForcedExitChecker {
-    /// Mimimum age of the account for `ForcedExit` operations to be allowed.
+    /// Minimum age of the account for `ForcedExit` operations to be allowed.
     pub forced_exit_minimum_account_age: chrono::Duration,
 }
 

--- a/core/bin/zksync_api/src/api_server/tx_sender.rs
+++ b/core/bin/zksync_api/src/api_server/tx_sender.rs
@@ -178,7 +178,7 @@ impl TxSender {
         }
     }
 
-    /// If `ForcedExit` has Ethereum siganture (e.g. it's a part of a batch), an actual signer
+    /// If `ForcedExit` has Ethereum signature (e.g. it's a part of a batch), an actual signer
     /// is initiator, not the target, thus, this function will perform a database query to acquire
     /// the corresponding address.
     async fn get_tx_sender(&self, tx: &ZkSyncTx) -> Result<Address, anyhow::Error> {

--- a/core/bin/zksync_core/src/state_keeper/mod.rs
+++ b/core/bin/zksync_core/src/state_keeper/mod.rs
@@ -777,7 +777,7 @@ impl ZkSyncStateKeeper {
         // TODO (ZKS-821): Currently the logic of this procedure is obscure and error-prone.
         // I've met multiple bugs trying to adapt it because it works at the same time with the "old"
         // pending block and "new" pending block. Actions "create block to be sealed" and "update pending block"
-        // should be spearated.
+        // should be separated.
         let current_block = self.pending_block.number;
         let next_unprocessed_priority_op = self.pending_block.unprocessed_priority_op_current;
         let new_pending_block = PendingBlock::new(

--- a/core/lib/circuit/benches/criterion/transfer.rs
+++ b/core/lib/circuit/benches/criterion/transfer.rs
@@ -10,7 +10,7 @@ use zksync_circuit::witness::transfer::TransferWitness;
 
 type TransferWitnessBn256 = TransferWitness<Bn256>;
 
-/// Measures the time of trasfer apply tx
+/// Measures the time of transfer apply tx
 fn transfer_apply_tx(b: &mut Bencher<'_>, number_of_accounts: &usize) {
     let accounts = generate_accounts(*number_of_accounts);
     let account_from = &accounts[0];

--- a/core/lib/circuit/src/circuit.rs
+++ b/core/lib/circuit/src/circuit.rs
@@ -4397,7 +4397,7 @@ pub fn check_account_data<E: RescueEngine, CS: ConstraintSystem<E>>(
 }
 
 /// Account tree state will be extended in the future, so for current balance tree we
-/// append emtpy hash to reserve place for the future tree before hashing.
+/// append empty hash to reserve place for the future tree before hashing.
 pub fn calc_account_state_tree_root<E: RescueEngine, CS: ConstraintSystem<E>>(
     mut cs: CS,
     balance_root: &CircuitElement<E>,


### PR DESCRIPTION
1. Fix `changelog/js-sdk.md`  typo
2. Fix `contracts/README.md`  typo
3. Fix `core/README.md`  typo
4. Fix `core/bin/zksync_api/src/api_server/forced_exit_checker.rs`  typo
5. Fix `core/bin/zksync_api/src/api_server/tx_sender.rs`  typo
6. Fix `core/bin/zksync_core/src/state_keeper/mod.rs`  typo
7. Fix `core/lib/circuit/benches/criterion/transfer.rs`  typo
8. Fix `core/lib/circuit/src/circuit.rs`  typo