### PR TITLE
Typo correction launch.md

### DIFF
--- a/docs/launch.md
+++ b/docs/launch.md
@@ -40,7 +40,7 @@ simply launch:
 zk up
 ```
 
-## (Re)deploy db and contraсts
+## (Re)deploy db and contracts
 
 ```
 zk contract redeploy


### PR DESCRIPTION
In the heading "(Re)deploy db and contraсts," the word "contraсts" uses the Cyrillic letter "_с_" instead of the English "**c**."

Corrected.