### PR TITLE
Fix grammatical and spelling errors

### DIFF
--- a/core/tests/loadnext/README.md
+++ b/core/tests/loadnext/README.md
@@ -1,13 +1,13 @@
 # Loadnext: the next generation loadtest for zkSync
 
-Loadnext is an utility for random stress-testing the zkSync server. It is capable of simulating the behavior of many
+Loadnext is a utility for random stress-testing the zkSync server. It is capable of simulating the behavior of many
 independent users of zkSync network, who are sending quasi-random requests to the server.
 
 It:
 
 - doesn't care whether the server is alive or not. At worst, it will just consider the test failed. No panics, no
   mindless unwraps, yay.
-- does a unique set of operations for each participating account.
+- performs a unique set of operations for each participating account.
 - sends transactions, batches, and priority operations.
 - sends incorrect transactions as well as correct ones and compares the outcome to the expected one.
 - has an easy-to-extend command system that allows adding new types of actions to the flow.
@@ -40,7 +40,7 @@ Without any configuration supplied, the test will fallback to the dev defaults:
 
 **Note:** when running the loadtest in the localhost scenario, you **must** adjust the supported block chunks sizes.
 Edit the `etc/env/dev/chain.toml` and set `block_chunk_sizes` to `[10,32,72,156,322,654]` and `aggregated_proof_sizes`
-to `[1,4,8,18]`. Do not forget to re-compile configs after that.
+to `[1,4,8,18]`. Do not forget to recompile the configs after that.
 
 This is required because the loadtest relies on batches, which will not fit into smaller block sizes.
 

--- a/sdk/zksync.js/README.md
+++ b/sdk/zksync.js/README.md
@@ -11,5 +11,5 @@ Full reference on how to use the library can be found [here](https://zksync.io/a
 
 ## Changelog
 
-The changelog of the zksync.js is avaliable
+The changelog of the zksync.js is available
 [here](https://github.com/matter-labs/zksync/blob/master/changelog/js-sdk.md).


### PR DESCRIPTION
Fixed:

Changed "Loadnext is an" to "Loadnext is a" for grammatical correctness.
Replaced "does a unique set of" with "performs a unique set of" for improved clarity.
Corrected "re-compile configs" to "recompile the configs" for proper phrasing.
Fixed "avaliable" to "available" for correct spelling.
Why it's useful:
These changes correct grammatical and spelling errors, enhancing clarity and readability.