### PR TITLE
Fix typo contract.md

### DIFF
--- a/docs/contract.md
+++ b/docs/contract.md
@@ -52,7 +52,7 @@ priority requests** are accrued to the owners' **root-chain balances** to make t
 
 It is a standard withdrawal operation. When a block with `partial_exit` **circuit operation** is committed, **withdraw
 onchain operation** for this withdrawal is created. If the block is verified, funds from the **withdrawal onchain
-operation** are acrued to the users' **root-chain balances**.
+operation** are accrued to the users' **root-chain balances**.
 
 If the block is reverted, this **withdraw onchain operations** are simply discarded.
 


### PR DESCRIPTION
### Summary
Fixes a typo in the `contract.md` file.

### Changes
- Corrected "acrued" to "accrued" in the documentation.

### Notes
- This is a minor documentation update to improve clarity and accuracy.
